### PR TITLE
Add restaurant discovery automation

### DIFF
--- a/.github/workflows/check-restaurants.yml
+++ b/.github/workflows/check-restaurants.yml
@@ -1,0 +1,37 @@
+name: Check restaurants
+
+on:
+  schedule:
+    - cron: '0 13 * * 1' # Mondays 13:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Configure git identity
+        run: |
+          git config user.name "del-ray-eats-bot"
+          git config user.email "bot@users.noreply.github.com"
+
+      - name: Run restaurant check
+        env:
+          GOOGLE_PLACES_API_KEY: ${{ secrets.GOOGLE_PLACES_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm check:restaurants

--- a/docs/superpowers/plans/2026-06-26-restaurant-discovery-automation.md
+++ b/docs/superpowers/plans/2026-06-26-restaurant-discovery-automation.md
@@ -1,0 +1,1710 @@
+# Restaurant Discovery Automation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A scheduled GitHub Action that calls the Google Places API to detect restaurants newly opened or permanently closed on the Del Ray stretch of Mount Vernon Ave, opening a PR for confirmed closures and an Issue for new candidates.
+
+**Architecture:** A TypeScript script in `scripts/check-restaurants/` split into a pure geometry/diff core (unit-tested), a mockable Places API client, and a reporter that performs file edits and `gh` Issue/PR side effects. An orchestrator wires them together behind injected effects so it is testable. A weekly GitHub Action runs it.
+
+**Tech Stack:** TypeScript (run with `tsx`), Vitest for tests, Google Places API (New) over `fetch`, GitHub Actions, `gh` CLI for Issue/PR creation, pnpm.
+
+## Global Constraints
+
+- Package manager is **pnpm**; install latest versions (no pinned versions unless required).
+- Node `>=22.12.0` (CI uses Node 24, matching local). ESM only (`"type"` is not set, but all script files use ESM `import`/`export` and `.ts`/`.mts`).
+- TypeScript extends `astro/tsconfigs/strictest` — no implicit `any`, strict null checks, `noUncheckedIndexedAccess`. All new code must satisfy it.
+- Prettier: single quotes, semicolons, 2-space indent, trailing commas, 80-col, `arrowParens: avoid`.
+- `src/data/restaurants.json` is the single source of truth. Each entry is `{ name, slug, website, onlineOrderUrl }`; this plan adds an optional `placeId`. `card.astro` must remain untouched and unaffected.
+- Every restaurant entry must have a matching `src/assets/images/<slug>.png` (the build throws otherwise), so removing an entry must also remove its image.
+- Closures: only `CLOSED_PERMANENTLY` is auto-removed. `CLOSED_TEMPORARILY`, dropped-out-but-operational, and not-found are reported only.
+- Safety guard: if Nearby Search returns fewer than `MIN_EXPECTED_RESULTS` corridor matches, abort with a non-zero exit and propose no removals.
+
+---
+
+## File Structure
+
+```
+scripts/check-restaurants/
+  types.ts          # shared types: LatLng, BusinessStatus, Restaurant, DiscoveredPlace
+  geo.ts            # pure geometry: haversine, point-to-segment, corridor test
+  geo.test.ts
+  diff.ts           # pure: slugify, name matching, diffRestaurants
+  diff.test.ts
+  config.ts         # corridor endpoints, widths, search params, type filter, guard threshold
+  places-client.ts  # Google Places API (New) client (network)
+  places-client.test.ts
+  report.ts         # pure builders: issue body, JSON mutation, image paths to delete
+  report.test.ts
+  effects.ts        # real side effects: fs + gh CLI (thin wrappers)
+  run.ts            # orchestration: run(client, effects) — testable
+  run.test.ts
+  main.ts           # entrypoint: wires real client + real effects, reads env
+vitest.config.ts
+.github/workflows/check-restaurants.yml
+```
+
+`package.json` gains devDeps (`vitest`, `tsx`, `@types/node`) and scripts (`test`, `check:restaurants`).
+
+---
+
+### Task 1: Test + runtime tooling
+
+**Files:**
+- Modify: `package.json`
+- Create: `vitest.config.ts`
+- Create: `scripts/check-restaurants/smoke.test.ts` (temporary, deleted at end of task)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: working `pnpm test` (vitest) and `tsx` available for running scripts.
+
+- [ ] **Step 1: Install dev dependencies**
+
+```bash
+pnpm add -D vitest tsx @types/node
+```
+
+- [ ] **Step 2: Add scripts to package.json**
+
+Add these two entries to the `"scripts"` block in `package.json` (keep existing entries):
+
+```json
+    "test": "vitest run",
+    "check:restaurants": "tsx scripts/check-restaurants/main.ts"
+```
+
+- [ ] **Step 3: Create vitest config**
+
+Create `vitest.config.ts`:
+
+```ts
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['scripts/**/*.test.ts'],
+    environment: 'node',
+  },
+});
+```
+
+- [ ] **Step 4: Write a smoke test**
+
+Create `scripts/check-restaurants/smoke.test.ts`:
+
+```ts
+import { expect, test } from 'vitest';
+
+test('vitest harness runs', () => {
+  expect(1 + 1).toBe(2);
+});
+```
+
+- [ ] **Step 5: Run the smoke test**
+
+Run: `pnpm test`
+Expected: PASS, 1 test passed.
+
+- [ ] **Step 6: Delete the smoke test and commit**
+
+```bash
+rm scripts/check-restaurants/smoke.test.ts
+git add package.json pnpm-lock.yaml vitest.config.ts
+git commit -m "chore: add vitest + tsx tooling for restaurant check script"
+```
+
+---
+
+### Task 2: Shared types
+
+**Files:**
+- Create: `scripts/check-restaurants/types.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `interface LatLng { lat: number; lng: number }`
+  - `type BusinessStatus = 'OPERATIONAL' | 'CLOSED_TEMPORARILY' | 'CLOSED_PERMANENTLY'`
+  - `interface Restaurant { name: string; slug: string; website: string; onlineOrderUrl: string; placeId?: string }`
+  - `interface DiscoveredPlace { placeId: string; name: string; location: LatLng; address: string; website: string | null; businessStatus: BusinessStatus }`
+
+This task has no test (pure type declarations). It is folded here because every later task consumes these types.
+
+- [ ] **Step 1: Create the types file**
+
+Create `scripts/check-restaurants/types.ts`:
+
+```ts
+export interface LatLng {
+  lat: number;
+  lng: number;
+}
+
+export type BusinessStatus =
+  | 'OPERATIONAL'
+  | 'CLOSED_TEMPORARILY'
+  | 'CLOSED_PERMANENTLY';
+
+export interface Restaurant {
+  name: string;
+  slug: string;
+  website: string;
+  onlineOrderUrl: string;
+  placeId?: string;
+}
+
+export interface DiscoveredPlace {
+  placeId: string;
+  name: string;
+  location: LatLng;
+  address: string;
+  website: string | null;
+  businessStatus: BusinessStatus;
+}
+```
+
+- [ ] **Step 2: Type-check and commit**
+
+Run: `pnpm exec tsc --noEmit -p tsconfig.json`
+Expected: no errors referencing `types.ts`.
+
+```bash
+git add scripts/check-restaurants/types.ts
+git commit -m "feat: add shared types for restaurant check script"
+```
+
+---
+
+### Task 3: Geometry core
+
+**Files:**
+- Create: `scripts/check-restaurants/geo.ts`
+- Test: `scripts/check-restaurants/geo.test.ts`
+
+**Interfaces:**
+- Consumes: `LatLng` from `./types`.
+- Produces:
+  - `haversineMeters(a: LatLng, b: LatLng): number`
+  - `projectToSegment(p: LatLng, a: LatLng, b: LatLng): { perpMeters: number; alongMeters: number; segLengthMeters: number }`
+  - `isWithinCorridor(p: LatLng, segStart: LatLng, segEnd: LatLng, widthMeters: number, endBufferMeters: number): boolean`
+
+`projectToSegment` uses a local equirectangular projection centered at `a`: convert lat/lng deltas to meters, then do 2-D vector projection. `alongMeters` is the signed distance from `a` along the segment direction (may be negative or exceed `segLengthMeters`). `perpMeters` is the absolute perpendicular distance.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `scripts/check-restaurants/geo.test.ts`:
+
+```ts
+import { describe, expect, test } from 'vitest';
+
+import { haversineMeters, isWithinCorridor, projectToSegment } from './geo';
+
+const BRADDOCK = { lat: 38.8204, lng: -77.061 };
+const COMMONWEALTH = { lat: 38.8348, lng: -77.0672 };
+
+describe('haversineMeters', () => {
+  test('zero distance for identical points', () => {
+    expect(haversineMeters(BRADDOCK, BRADDOCK)).toBeCloseTo(0, 5);
+  });
+
+  test('matches known distance between the two endpoints (~1.65 km)', () => {
+    const d = haversineMeters(BRADDOCK, COMMONWEALTH);
+    expect(d).toBeGreaterThan(1500);
+    expect(d).toBeLessThan(1800);
+  });
+});
+
+describe('projectToSegment', () => {
+  test('a point on the segment start has ~0 perpendicular and ~0 along distance', () => {
+    const r = projectToSegment(BRADDOCK, BRADDOCK, COMMONWEALTH);
+    expect(r.perpMeters).toBeCloseTo(0, 1);
+    expect(r.alongMeters).toBeCloseTo(0, 1);
+  });
+
+  test('along distance at the end equals segment length', () => {
+    const r = projectToSegment(COMMONWEALTH, BRADDOCK, COMMONWEALTH);
+    expect(r.alongMeters).toBeCloseTo(r.segLengthMeters, 0);
+  });
+});
+
+describe('isWithinCorridor', () => {
+  test('point near the midpoint of the avenue is inside', () => {
+    const mid = { lat: 38.8276, lng: -77.0641 };
+    expect(isWithinCorridor(mid, BRADDOCK, COMMONWEALTH, 150, 50)).toBe(true);
+  });
+
+  test('point ~one block (120 m) east is still inside a 150 m corridor', () => {
+    // ~120 m east ≈ +0.00138 deg lng at this latitude
+    const eastOfAvenue = { lat: 38.8276, lng: -77.0641 + 0.00138 };
+    expect(isWithinCorridor(eastOfAvenue, BRADDOCK, COMMONWEALTH, 150, 50)).toBe(
+      true,
+    );
+  });
+
+  test('point ~400 m east is outside a 150 m corridor', () => {
+    const farEast = { lat: 38.8276, lng: -77.0641 + 0.0046 };
+    expect(isWithinCorridor(farEast, BRADDOCK, COMMONWEALTH, 150, 50)).toBe(
+      false,
+    );
+  });
+
+  test('point well south of Braddock is outside (beyond end buffer)', () => {
+    const south = { lat: 38.815, lng: -77.0595 };
+    expect(isWithinCorridor(south, BRADDOCK, COMMONWEALTH, 150, 50)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test scripts/check-restaurants/geo.test.ts`
+Expected: FAIL with "Cannot find module './geo'" / functions not defined.
+
+- [ ] **Step 3: Implement the geometry**
+
+Create `scripts/check-restaurants/geo.ts`:
+
+```ts
+import type { LatLng } from './types';
+
+const EARTH_RADIUS_M = 6_371_000;
+
+const toRad = (deg: number): number => (deg * Math.PI) / 180;
+
+export function haversineMeters(a: LatLng, b: LatLng): number {
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+  const lat1 = toRad(a.lat);
+  const lat2 = toRad(b.lat);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2;
+  return 2 * EARTH_RADIUS_M * Math.asin(Math.sqrt(h));
+}
+
+// Local equirectangular projection: returns metric (x east, y north) relative
+// to the origin point. Accurate over the short distances used here.
+function toLocalMeters(p: LatLng, origin: LatLng): { x: number; y: number } {
+  const x = toRad(p.lng - origin.lng) * Math.cos(toRad(origin.lat)) *
+    EARTH_RADIUS_M;
+  const y = toRad(p.lat - origin.lat) * EARTH_RADIUS_M;
+  return { x, y };
+}
+
+export function projectToSegment(
+  p: LatLng,
+  a: LatLng,
+  b: LatLng,
+): { perpMeters: number; alongMeters: number; segLengthMeters: number } {
+  const pv = toLocalMeters(p, a);
+  const bv = toLocalMeters(b, a);
+  const segLengthMeters = Math.hypot(bv.x, bv.y);
+  if (segLengthMeters === 0) {
+    return {
+      perpMeters: Math.hypot(pv.x, pv.y),
+      alongMeters: 0,
+      segLengthMeters: 0,
+    };
+  }
+  const ux = bv.x / segLengthMeters;
+  const uy = bv.y / segLengthMeters;
+  const alongMeters = pv.x * ux + pv.y * uy;
+  const perpMeters = Math.abs(pv.x * uy - pv.y * ux);
+  return { perpMeters, alongMeters, segLengthMeters };
+}
+
+export function isWithinCorridor(
+  p: LatLng,
+  segStart: LatLng,
+  segEnd: LatLng,
+  widthMeters: number,
+  endBufferMeters: number,
+): boolean {
+  const { perpMeters, alongMeters, segLengthMeters } = projectToSegment(
+    p,
+    segStart,
+    segEnd,
+  );
+  return (
+    perpMeters <= widthMeters &&
+    alongMeters >= -endBufferMeters &&
+    alongMeters <= segLengthMeters + endBufferMeters
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test scripts/check-restaurants/geo.test.ts`
+Expected: PASS, all geo tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/check-restaurants/geo.ts scripts/check-restaurants/geo.test.ts
+git commit -m "feat: add corridor geometry for restaurant check"
+```
+
+---
+
+### Task 4: Config
+
+**Files:**
+- Create: `scripts/check-restaurants/config.ts`
+
+**Interfaces:**
+- Consumes: `LatLng` from `./types`.
+- Produces: `SEGMENT_START`, `SEGMENT_END`, `SEARCH_CENTER` (`LatLng`); `CORRIDOR_WIDTH_METERS`, `CORRIDOR_END_BUFFER_METERS`, `SEARCH_RADIUS_METERS`, `MIN_EXPECTED_RESULTS` (numbers); `INCLUDED_TYPES` (`readonly string[]`).
+
+The two endpoint coordinates are approximate. **Before committing, verify them:** open Google Maps, find the Mount Vernon Ave ∩ E Braddock Rd intersection (south) and the Mount Vernon Ave ∩ Commonwealth Ave intersection (north), right-click → copy the lat/lng, and replace the values below if they differ materially. They are tunable; the corridor width absorbs small errors.
+
+- [ ] **Step 1: Create the config file**
+
+Create `scripts/check-restaurants/config.ts`:
+
+```ts
+import type { LatLng } from './types';
+
+// Mount Vernon Ave ∩ E Braddock Rd (south end of the strip). Verify in Maps.
+export const SEGMENT_START: LatLng = { lat: 38.8204, lng: -77.061 };
+
+// Mount Vernon Ave ∩ Commonwealth Ave (north end of the strip). Verify in Maps.
+export const SEGMENT_END: LatLng = { lat: 38.8348, lng: -77.0672 };
+
+// Center and radius of the Nearby Search circle covering the whole strip.
+export const SEARCH_CENTER: LatLng = { lat: 38.8276, lng: -77.0641 };
+export const SEARCH_RADIUS_METERS = 1200;
+
+// Corridor: keep places within this perpendicular distance of the avenue line,
+// extended slightly past each endpoint. ~150 m ≈ one block east/west.
+export const CORRIDOR_WIDTH_METERS = 150;
+export const CORRIDOR_END_BUFFER_METERS = 50;
+
+// Abort and propose no removals if fewer than this many corridor matches return.
+export const MIN_EXPECTED_RESULTS = 10;
+
+// Broad type filter — the list includes a bakery, a coffee pub, a cheese shop.
+export const INCLUDED_TYPES: readonly string[] = [
+  'restaurant',
+  'cafe',
+  'coffee_shop',
+  'bakery',
+  'bar',
+  'meal_takeaway',
+  'meal_delivery',
+  'ice_cream_shop',
+  'sandwich_shop',
+  'pizza_restaurant',
+];
+```
+
+- [ ] **Step 2: Type-check and commit**
+
+Run: `pnpm exec tsc --noEmit -p tsconfig.json`
+Expected: no errors referencing `config.ts`.
+
+```bash
+git add scripts/check-restaurants/config.ts
+git commit -m "feat: add config for restaurant corridor + search params"
+```
+
+---
+
+### Task 5: Diff core
+
+**Files:**
+- Create: `scripts/check-restaurants/diff.ts`
+- Test: `scripts/check-restaurants/diff.test.ts`
+
+**Interfaces:**
+- Consumes: `Restaurant`, `DiscoveredPlace`, `BusinessStatus` from `./types`.
+- Produces:
+  - `slugify(name: string): string`
+  - `normalizeName(name: string): string`
+  - `nameSimilarity(a: string, b: string): number` (Jaccard over normalized tokens, 0..1)
+  - `interface DiffResult { additions: DiscoveredPlace[]; closures: Restaurant[]; backfills: Array<{ slug: string; placeId: string }>; warnings: string[] }`
+  - `diffRestaurants(existing: Restaurant[], discovered: DiscoveredPlace[], existingStatuses: Map<string, BusinessStatus | 'NOT_FOUND'>): DiffResult`
+
+Logic:
+- **closures:** existing entries whose `placeId` maps to `CLOSED_PERMANENTLY`.
+- **backfills:** existing entries with no `placeId`, fuzzy-matched (similarity ≥ 0.6) to a discovered place; record `{ slug, placeId }`.
+- **additions:** discovered places whose `placeId` is not held by any existing entry AND that did not match an existing entry by name.
+- **warnings:** existing `placeId` mapping to `CLOSED_TEMPORARILY`; existing `placeId` mapping to `NOT_FOUND`; existing entry that is `OPERATIONAL`/known but absent from `discovered` (dropped out of corridor).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `scripts/check-restaurants/diff.test.ts`:
+
+```ts
+import { describe, expect, test } from 'vitest';
+
+import { diffRestaurants, nameSimilarity, slugify } from './diff';
+import type { BusinessStatus, DiscoveredPlace, Restaurant } from './types';
+
+const place = (over: Partial<DiscoveredPlace>): DiscoveredPlace => ({
+  placeId: 'p-default',
+  name: 'Some Place',
+  location: { lat: 38.8276, lng: -77.0641 },
+  address: '123 Mount Vernon Ave',
+  website: null,
+  businessStatus: 'OPERATIONAL',
+  ...over,
+});
+
+const restaurant = (over: Partial<Restaurant>): Restaurant => ({
+  name: 'Some Place',
+  slug: 'some-place',
+  website: 'https://example.com',
+  onlineOrderUrl: 'https://example.com/order',
+  ...over,
+});
+
+describe('slugify', () => {
+  test('lowercases, strips punctuation, hyphenates', () => {
+    expect(slugify("Matt & Tony's All Day Kitchen + Bar")).toBe(
+      'matt-tonys-all-day-kitchen-bar',
+    );
+  });
+
+  test('collapses repeated separators and trims', () => {
+    expect(slugify('  Hi/Fi  Tex-Mex  BBQ ')).toBe('hifi-tex-mex-bbq');
+  });
+});
+
+describe('nameSimilarity', () => {
+  test('identical names score 1', () => {
+    expect(nameSimilarity('Thai Peppers', 'Thai Peppers')).toBe(1);
+  });
+
+  test('related names score above the 0.6 threshold', () => {
+    expect(
+      nameSimilarity('Del Ray Cafe', 'Del Ray Café Restaurant'),
+    ).toBeGreaterThanOrEqual(0.6);
+  });
+
+  test('unrelated names score below threshold', () => {
+    expect(nameSimilarity('Thai Peppers', 'Pork Barrel BBQ')).toBeLessThan(0.6);
+  });
+});
+
+describe('diffRestaurants', () => {
+  test('flags a permanently closed existing restaurant as a closure', () => {
+    const existing = [restaurant({ slug: 'gone', placeId: 'p-gone' })];
+    const statuses = new Map<string, BusinessStatus | 'NOT_FOUND'>([
+      ['p-gone', 'CLOSED_PERMANENTLY'],
+    ]);
+    const result = diffRestaurants(existing, [], statuses);
+    expect(result.closures.map(r => r.slug)).toEqual(['gone']);
+    expect(result.additions).toEqual([]);
+  });
+
+  test('flags an unknown discovered place as an addition', () => {
+    const existing = [restaurant({ slug: 'keep', placeId: 'p-keep' })];
+    const discovered = [
+      place({ placeId: 'p-keep', name: 'Keep' }),
+      place({ placeId: 'p-new', name: 'Brand New Spot' }),
+    ];
+    const statuses = new Map<string, BusinessStatus | 'NOT_FOUND'>([
+      ['p-keep', 'OPERATIONAL'],
+    ]);
+    const result = diffRestaurants(existing, discovered, statuses);
+    expect(result.additions.map(p => p.placeId)).toEqual(['p-new']);
+    expect(result.closures).toEqual([]);
+  });
+
+  test('backfills placeId for an existing entry with no placeId via name match', () => {
+    const existing = [restaurant({ name: 'Thai Peppers', slug: 'thai-peppers' })];
+    const discovered = [place({ placeId: 'p-thai', name: 'Thai Peppers' })];
+    const statuses = new Map<string, BusinessStatus | 'NOT_FOUND'>();
+    const result = diffRestaurants(existing, discovered, statuses);
+    expect(result.backfills).toEqual([{ slug: 'thai-peppers', placeId: 'p-thai' }]);
+    // matched by name, so NOT an addition
+    expect(result.additions).toEqual([]);
+  });
+
+  test('warns on temporarily closed and on dropped-out operational entries', () => {
+    const existing = [
+      restaurant({ slug: 'temp', placeId: 'p-temp' }),
+      restaurant({ slug: 'dropped', placeId: 'p-dropped' }),
+    ];
+    const statuses = new Map<string, BusinessStatus | 'NOT_FOUND'>([
+      ['p-temp', 'CLOSED_TEMPORARILY'],
+      ['p-dropped', 'OPERATIONAL'],
+    ]);
+    // p-dropped is operational but not in discovered list
+    const result = diffRestaurants(existing, [], statuses);
+    expect(result.closures).toEqual([]);
+    expect(result.warnings.some(w => w.includes('temp'))).toBe(true);
+    expect(result.warnings.some(w => w.includes('dropped'))).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test scripts/check-restaurants/diff.test.ts`
+Expected: FAIL with "Cannot find module './diff'".
+
+- [ ] **Step 3: Implement the diff core**
+
+Create `scripts/check-restaurants/diff.ts`:
+
+```ts
+import type {
+  BusinessStatus,
+  DiscoveredPlace,
+  Restaurant,
+} from './types';
+
+const NAME_MATCH_THRESHOLD = 0.6;
+
+const STOPWORDS = new Set([
+  'the',
+  'restaurant',
+  'cafe',
+  'and',
+  'of',
+  'del',
+  'ray',
+  'va',
+]);
+
+export function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function normalizeName(name: string): string {
+  return name
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function tokens(name: string): Set<string> {
+  return new Set(
+    normalizeName(name)
+      .split(' ')
+      .filter(t => t.length > 0 && !STOPWORDS.has(t)),
+  );
+}
+
+export function nameSimilarity(a: string, b: string): number {
+  const ta = tokens(a);
+  const tb = tokens(b);
+  if (ta.size === 0 && tb.size === 0) return 1;
+  if (ta.size === 0 || tb.size === 0) return 0;
+  let intersection = 0;
+  for (const t of ta) if (tb.has(t)) intersection += 1;
+  const union = ta.size + tb.size - intersection;
+  return intersection / union;
+}
+
+export interface DiffResult {
+  additions: DiscoveredPlace[];
+  closures: Restaurant[];
+  backfills: Array<{ slug: string; placeId: string }>;
+  warnings: string[];
+}
+
+export function diffRestaurants(
+  existing: Restaurant[],
+  discovered: DiscoveredPlace[],
+  existingStatuses: Map<string, BusinessStatus | 'NOT_FOUND'>,
+): DiffResult {
+  const result: DiffResult = {
+    additions: [],
+    closures: [],
+    backfills: [],
+    warnings: [],
+  };
+
+  const knownPlaceIds = new Set(
+    existing.map(r => r.placeId).filter((id): id is string => Boolean(id)),
+  );
+  const matchedDiscoveredIds = new Set<string>();
+
+  // Backfill placeIds for existing entries that lack one, via name match.
+  for (const r of existing) {
+    if (r.placeId) continue;
+    let best: { place: DiscoveredPlace; score: number } | null = null;
+    for (const d of discovered) {
+      const score = nameSimilarity(r.name, d.name);
+      if (!best || score > best.score) best = { place: d, score };
+    }
+    if (best && best.score >= NAME_MATCH_THRESHOLD) {
+      result.backfills.push({ slug: r.slug, placeId: best.place.placeId });
+      knownPlaceIds.add(best.place.placeId);
+      matchedDiscoveredIds.add(best.place.placeId);
+    }
+  }
+
+  // Closures + warnings, driven by status of existing entries.
+  for (const r of existing) {
+    if (!r.placeId) continue;
+    const status = existingStatuses.get(r.placeId);
+    if (status === 'CLOSED_PERMANENTLY') {
+      result.closures.push(r);
+    } else if (status === 'CLOSED_TEMPORARILY') {
+      result.warnings.push(
+        `${r.slug}: reported CLOSED_TEMPORARILY — not removing, verify manually.`,
+      );
+    } else if (status === 'NOT_FOUND') {
+      result.warnings.push(
+        `${r.slug}: placeId ${r.placeId} not found by Places — verify manually.`,
+      );
+    } else if (!discovered.some(d => d.placeId === r.placeId)) {
+      result.warnings.push(
+        `${r.slug}: operational but absent from corridor search — verify it has not moved.`,
+      );
+    }
+  }
+
+  // Additions: discovered places not known and not name-matched to existing.
+  for (const d of discovered) {
+    if (knownPlaceIds.has(d.placeId) || matchedDiscoveredIds.has(d.placeId)) {
+      continue;
+    }
+    const nameMatch = existing.some(
+      r => nameSimilarity(r.name, d.name) >= NAME_MATCH_THRESHOLD,
+    );
+    if (!nameMatch) result.additions.push(d);
+  }
+
+  return result;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test scripts/check-restaurants/diff.test.ts`
+Expected: PASS, all diff tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/check-restaurants/diff.ts scripts/check-restaurants/diff.test.ts
+git commit -m "feat: add diff core for restaurant additions/closures"
+```
+
+---
+
+### Task 6: Places API client
+
+**Files:**
+- Create: `scripts/check-restaurants/places-client.ts`
+- Test: `scripts/check-restaurants/places-client.test.ts`
+
+**Interfaces:**
+- Consumes: `DiscoveredPlace`, `BusinessStatus` from `./types`; config values from `./config`.
+- Produces:
+  - `interface PlacesClient { searchNearby(): Promise<DiscoveredPlace[]>; getPlaceStatus(placeId: string): Promise<BusinessStatus | 'NOT_FOUND'> }`
+  - `createPlacesClient(apiKey: string, fetchFn?: typeof fetch): PlacesClient`
+
+`searchNearby` POSTs to `https://places.googleapis.com/v1/places:searchNearby` with the config circle + `INCLUDED_TYPES`, requesting a field mask. `getPlaceStatus` GETs `https://places.googleapis.com/v1/places/{placeId}` with a `businessStatus` field mask; a 404 yields `'NOT_FOUND'`. `fetchFn` defaults to global `fetch` and is injected in tests.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `scripts/check-restaurants/places-client.test.ts`:
+
+```ts
+import { describe, expect, test, vi } from 'vitest';
+
+import { createPlacesClient } from './places-client';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('searchNearby', () => {
+  test('maps API places into DiscoveredPlace and sends key + field mask', async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonResponse({
+        places: [
+          {
+            id: 'p-1',
+            displayName: { text: 'Lena’s' },
+            formattedAddress: '401 E Braddock Rd',
+            location: { latitude: 38.83, longitude: -77.065 },
+            websiteUri: 'https://lenaswoodfire.com',
+            businessStatus: 'OPERATIONAL',
+          },
+        ],
+      }),
+    );
+    const client = createPlacesClient('KEY', fetchFn as unknown as typeof fetch);
+    const places = await client.searchNearby();
+
+    expect(places).toHaveLength(1);
+    expect(places[0]).toMatchObject({
+      placeId: 'p-1',
+      name: 'Lena’s',
+      address: '401 E Braddock Rd',
+      website: 'https://lenaswoodfire.com',
+      businessStatus: 'OPERATIONAL',
+      location: { lat: 38.83, lng: -77.065 },
+    });
+
+    const [url, init] = fetchFn.mock.calls[0];
+    expect(String(url)).toContain('places:searchNearby');
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers['X-Goog-Api-Key']).toBe('KEY');
+    expect(headers['X-Goog-FieldMask']).toContain('places.businessStatus');
+  });
+
+  test('defaults website to null when absent', async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonResponse({
+        places: [
+          {
+            id: 'p-2',
+            displayName: { text: 'No Site' },
+            formattedAddress: '1 Mount Vernon Ave',
+            location: { latitude: 38.82, longitude: -77.06 },
+            businessStatus: 'OPERATIONAL',
+          },
+        ],
+      }),
+    );
+    const client = createPlacesClient('KEY', fetchFn as unknown as typeof fetch);
+    const places = await client.searchNearby();
+    expect(places[0]?.website).toBeNull();
+  });
+
+  test('throws on non-OK search response', async () => {
+    const fetchFn = vi.fn(async () => jsonResponse({ error: 'bad' }, 400));
+    const client = createPlacesClient('KEY', fetchFn as unknown as typeof fetch);
+    await expect(client.searchNearby()).rejects.toThrow();
+  });
+});
+
+describe('getPlaceStatus', () => {
+  test('returns the business status', async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonResponse({ businessStatus: 'CLOSED_PERMANENTLY' }),
+    );
+    const client = createPlacesClient('KEY', fetchFn as unknown as typeof fetch);
+    expect(await client.getPlaceStatus('p-x')).toBe('CLOSED_PERMANENTLY');
+  });
+
+  test('returns NOT_FOUND on 404', async () => {
+    const fetchFn = vi.fn(async () => jsonResponse({ error: 'no' }, 404));
+    const client = createPlacesClient('KEY', fetchFn as unknown as typeof fetch);
+    expect(await client.getPlaceStatus('p-missing')).toBe('NOT_FOUND');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test scripts/check-restaurants/places-client.test.ts`
+Expected: FAIL with "Cannot find module './places-client'".
+
+- [ ] **Step 3: Implement the client**
+
+Create `scripts/check-restaurants/places-client.ts`:
+
+```ts
+import {
+  INCLUDED_TYPES,
+  SEARCH_CENTER,
+  SEARCH_RADIUS_METERS,
+} from './config';
+import type { BusinessStatus, DiscoveredPlace } from './types';
+
+const SEARCH_URL = 'https://places.googleapis.com/v1/places:searchNearby';
+const DETAILS_URL = 'https://places.googleapis.com/v1/places';
+
+const SEARCH_FIELD_MASK = [
+  'places.id',
+  'places.displayName',
+  'places.formattedAddress',
+  'places.location',
+  'places.websiteUri',
+  'places.businessStatus',
+].join(',');
+
+interface ApiPlace {
+  id: string;
+  displayName?: { text?: string };
+  formattedAddress?: string;
+  location?: { latitude: number; longitude: number };
+  websiteUri?: string;
+  businessStatus?: BusinessStatus;
+}
+
+export interface PlacesClient {
+  searchNearby(): Promise<DiscoveredPlace[]>;
+  getPlaceStatus(placeId: string): Promise<BusinessStatus | 'NOT_FOUND'>;
+}
+
+function mapPlace(p: ApiPlace): DiscoveredPlace {
+  return {
+    placeId: p.id,
+    name: p.displayName?.text ?? '',
+    address: p.formattedAddress ?? '',
+    location: {
+      lat: p.location?.latitude ?? 0,
+      lng: p.location?.longitude ?? 0,
+    },
+    website: p.websiteUri ?? null,
+    businessStatus: p.businessStatus ?? 'OPERATIONAL',
+  };
+}
+
+export function createPlacesClient(
+  apiKey: string,
+  fetchFn: typeof fetch = fetch,
+): PlacesClient {
+  return {
+    async searchNearby(): Promise<DiscoveredPlace[]> {
+      const res = await fetchFn(SEARCH_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Goog-Api-Key': apiKey,
+          'X-Goog-FieldMask': SEARCH_FIELD_MASK,
+        },
+        body: JSON.stringify({
+          includedTypes: INCLUDED_TYPES,
+          maxResultCount: 20,
+          locationRestriction: {
+            circle: {
+              center: {
+                latitude: SEARCH_CENTER.lat,
+                longitude: SEARCH_CENTER.lng,
+              },
+              radius: SEARCH_RADIUS_METERS,
+            },
+          },
+        }),
+      });
+      if (!res.ok) {
+        throw new Error(
+          `Places searchNearby failed: ${res.status} ${await res.text()}`,
+        );
+      }
+      const data = (await res.json()) as { places?: ApiPlace[] };
+      return (data.places ?? []).map(mapPlace);
+    },
+
+    async getPlaceStatus(
+      placeId: string,
+    ): Promise<BusinessStatus | 'NOT_FOUND'> {
+      const res = await fetchFn(`${DETAILS_URL}/${placeId}`, {
+        method: 'GET',
+        headers: {
+          'X-Goog-Api-Key': apiKey,
+          'X-Goog-FieldMask': 'businessStatus',
+        },
+      });
+      if (res.status === 404) return 'NOT_FOUND';
+      if (!res.ok) {
+        throw new Error(
+          `Places details failed: ${res.status} ${await res.text()}`,
+        );
+      }
+      const data = (await res.json()) as { businessStatus?: BusinessStatus };
+      return data.businessStatus ?? 'NOT_FOUND';
+    },
+  };
+}
+```
+
+Note: Nearby Search (New) caps `maxResultCount` at 20. The corridor is small, but if the strip ever exceeds 20 raw results this would truncate; acceptable for now (documented limitation).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test scripts/check-restaurants/places-client.test.ts`
+Expected: PASS, all client tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/check-restaurants/places-client.ts scripts/check-restaurants/places-client.test.ts
+git commit -m "feat: add Google Places API client"
+```
+
+---
+
+### Task 7: Reporter (pure builders)
+
+**Files:**
+- Create: `scripts/check-restaurants/report.ts`
+- Test: `scripts/check-restaurants/report.test.ts`
+
+**Interfaces:**
+- Consumes: `Restaurant`, `DiscoveredPlace` from `./types`; `slugify` from `./diff`.
+- Produces:
+  - `buildIssueBody(additions: DiscoveredPlace[], warnings: string[]): string`
+  - `applyClosures(restaurants: Restaurant[], closures: Restaurant[]): Restaurant[]`
+  - `applyBackfills(restaurants: Restaurant[], backfills: Array<{ slug: string; placeId: string }>): Restaurant[]`
+  - `imageFilesToDelete(closures: Restaurant[]): string[]` (paths like `src/assets/images/<slug>.png`)
+  - `serializeRestaurants(restaurants: Restaurant[]): string` (2-space JSON + trailing newline, matching the existing file)
+
+`applyClosures`/`applyBackfills` return new arrays (no mutation). The issue body is deterministic markdown.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `scripts/check-restaurants/report.test.ts`:
+
+```ts
+import { describe, expect, test } from 'vitest';
+
+import {
+  applyBackfills,
+  applyClosures,
+  buildIssueBody,
+  imageFilesToDelete,
+  serializeRestaurants,
+} from './report';
+import type { DiscoveredPlace, Restaurant } from './types';
+
+const r = (over: Partial<Restaurant>): Restaurant => ({
+  name: 'X',
+  slug: 'x',
+  website: 'https://x.com',
+  onlineOrderUrl: 'https://x.com/order',
+  ...over,
+});
+
+const d = (over: Partial<DiscoveredPlace>): DiscoveredPlace => ({
+  placeId: 'p-new',
+  name: 'New Spot',
+  location: { lat: 38.8276, lng: -77.0641 },
+  address: '2000 Mount Vernon Ave',
+  website: 'https://newspot.com',
+  businessStatus: 'OPERATIONAL',
+  ...over,
+});
+
+describe('applyClosures', () => {
+  test('removes closed entries, leaves the rest, does not mutate input', () => {
+    const input = [r({ slug: 'keep' }), r({ slug: 'gone' })];
+    const out = applyClosures(input, [r({ slug: 'gone' })]);
+    expect(out.map(x => x.slug)).toEqual(['keep']);
+    expect(input).toHaveLength(2);
+  });
+});
+
+describe('applyBackfills', () => {
+  test('sets placeId on matching slugs only', () => {
+    const input = [r({ slug: 'a' }), r({ slug: 'b' })];
+    const out = applyBackfills(input, [{ slug: 'b', placeId: 'p-b' }]);
+    expect(out.find(x => x.slug === 'a')?.placeId).toBeUndefined();
+    expect(out.find(x => x.slug === 'b')?.placeId).toBe('p-b');
+  });
+});
+
+describe('imageFilesToDelete', () => {
+  test('maps slugs to image paths', () => {
+    expect(imageFilesToDelete([r({ slug: 'gone' })])).toEqual([
+      'src/assets/images/gone.png',
+    ]);
+  });
+});
+
+describe('serializeRestaurants', () => {
+  test('2-space indented JSON ending in a newline', () => {
+    const out = serializeRestaurants([r({ slug: 'x' })]);
+    expect(out.endsWith('\n')).toBe(true);
+    expect(out).toContain('  "slug": "x"');
+  });
+});
+
+describe('buildIssueBody', () => {
+  test('includes addition name, website, slug suggestion, and placeId', () => {
+    const body = buildIssueBody([d({ name: 'New Spot' })], []);
+    expect(body).toContain('New Spot');
+    expect(body).toContain('https://newspot.com');
+    expect(body).toContain('new-spot');
+    expect(body).toContain('p-new');
+    expect(body).toContain('maps.google.com');
+  });
+
+  test('renders warnings section when present', () => {
+    const body = buildIssueBody([], ['thai-peppers: verify manually.']);
+    expect(body).toContain('Warnings');
+    expect(body).toContain('thai-peppers: verify manually.');
+  });
+
+  test('states when there is nothing to add', () => {
+    const body = buildIssueBody([], []);
+    expect(body.toLowerCase()).toContain('no new');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test scripts/check-restaurants/report.test.ts`
+Expected: FAIL with "Cannot find module './report'".
+
+- [ ] **Step 3: Implement the reporter**
+
+Create `scripts/check-restaurants/report.ts`:
+
+```ts
+import { slugify } from './diff';
+import type { DiscoveredPlace, Restaurant } from './types';
+
+export function applyClosures(
+  restaurants: Restaurant[],
+  closures: Restaurant[],
+): Restaurant[] {
+  const closedSlugs = new Set(closures.map(c => c.slug));
+  return restaurants.filter(r => !closedSlugs.has(r.slug));
+}
+
+export function applyBackfills(
+  restaurants: Restaurant[],
+  backfills: Array<{ slug: string; placeId: string }>,
+): Restaurant[] {
+  const bySlug = new Map(backfills.map(b => [b.slug, b.placeId]));
+  return restaurants.map(r => {
+    const placeId = bySlug.get(r.slug);
+    return placeId ? { ...r, placeId } : r;
+  });
+}
+
+export function imageFilesToDelete(closures: Restaurant[]): string[] {
+  return closures.map(c => `src/assets/images/${c.slug}.png`);
+}
+
+export function serializeRestaurants(restaurants: Restaurant[]): string {
+  return `${JSON.stringify(restaurants, null, 2)}\n`;
+}
+
+export function buildIssueBody(
+  additions: DiscoveredPlace[],
+  warnings: string[],
+): string {
+  const lines: string[] = [];
+  lines.push('## Restaurant directory check');
+  lines.push('');
+
+  if (additions.length === 0) {
+    lines.push('No new restaurant candidates found.');
+  } else {
+    lines.push(`### ${additions.length} new candidate(s)`);
+    lines.push('');
+    lines.push(
+      'Finish each by adding an `onlineOrderUrl` and a `<slug>.png` image.',
+    );
+    lines.push('');
+    for (const a of additions) {
+      const slug = slugify(a.name);
+      const mapsUrl = `https://maps.google.com/?q=place_id:${a.placeId}`;
+      lines.push(`- **${a.name}**`);
+      lines.push(`  - Address: ${a.address}`);
+      lines.push(`  - Website: ${a.website ?? '(none provided)'}`);
+      lines.push(`  - Suggested slug: \`${slug}\``);
+      lines.push(`  - placeId: \`${a.placeId}\``);
+      lines.push(`  - Google Maps: ${mapsUrl}`);
+    }
+  }
+
+  if (warnings.length > 0) {
+    lines.push('');
+    lines.push('### Warnings');
+    lines.push('');
+    for (const w of warnings) lines.push(`- ${w}`);
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test scripts/check-restaurants/report.test.ts`
+Expected: PASS, all reporter tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/check-restaurants/report.ts scripts/check-restaurants/report.test.ts
+git commit -m "feat: add reporter builders for issue body + json mutation"
+```
+
+---
+
+### Task 8: Orchestration
+
+**Files:**
+- Create: `scripts/check-restaurants/run.ts`
+- Test: `scripts/check-restaurants/run.test.ts`
+
+**Interfaces:**
+- Consumes: `PlacesClient` from `./places-client`; `isWithinCorridor` from `./geo`; `diffRestaurants` from `./diff`; reporter builders from `./report`; config from `./config`; types from `./types`.
+- Produces:
+  - `interface Effects { readRestaurants(): Promise<Restaurant[]>; writeRestaurants(json: string): Promise<void>; deleteImages(paths: string[]): Promise<void>; reportIssue(body: string): Promise<void>; openClosurePr(removed: Restaurant[]): Promise<void>; log(msg: string): void }`
+  - `interface RunResult { additions: number; closures: number; backfills: number; warnings: number; aborted: boolean }`
+  - `run(client: PlacesClient, effects: Effects): Promise<RunResult>`
+
+Flow: search → corridor-filter → fetch statuses for existing placeIds → guard (`< MIN_EXPECTED_RESULTS` ⇒ abort, no removals) → diff → apply backfills + closures, write JSON, delete images, open closure PR if any → always report issue.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `scripts/check-restaurants/run.test.ts`:
+
+```ts
+import { describe, expect, test, vi } from 'vitest';
+
+import type { PlacesClient } from './places-client';
+import { run, type Effects } from './run';
+import type { BusinessStatus, DiscoveredPlace, Restaurant } from './types';
+
+const onAvenue = { lat: 38.8276, lng: -77.0641 };
+
+function fakeClient(
+  discovered: DiscoveredPlace[],
+  statuses: Record<string, BusinessStatus | 'NOT_FOUND'>,
+): PlacesClient {
+  return {
+    searchNearby: async () => discovered,
+    getPlaceStatus: async id => statuses[id] ?? 'NOT_FOUND',
+  };
+}
+
+function fakeEffects(existing: Restaurant[]): Effects & {
+  written: string[];
+  deleted: string[];
+  issues: string[];
+  prs: Restaurant[][];
+} {
+  const written: string[] = [];
+  const deleted: string[] = [];
+  const issues: string[] = [];
+  const prs: Restaurant[][] = [];
+  return {
+    written,
+    deleted,
+    issues,
+    prs,
+    readRestaurants: async () => existing,
+    writeRestaurants: async json => {
+      written.push(json);
+    },
+    deleteImages: async paths => {
+      deleted.push(...paths);
+    },
+    reportIssue: async body => {
+      issues.push(body);
+    },
+    openClosurePr: async removed => {
+      prs.push(removed);
+    },
+    log: () => {},
+  };
+}
+
+function place(over: Partial<DiscoveredPlace>): DiscoveredPlace {
+  return {
+    placeId: 'p',
+    name: 'P',
+    location: onAvenue,
+    address: '2000 Mount Vernon Ave',
+    website: null,
+    businessStatus: 'OPERATIONAL',
+    ...over,
+  };
+}
+
+// Build N operational corridor places so the guard passes.
+function padPlaces(n: number): DiscoveredPlace[] {
+  return Array.from({ length: n }, (_, i) =>
+    place({ placeId: `pad-${i}`, name: `Pad ${i}` }),
+  );
+}
+
+describe('run', () => {
+  test('aborts without removals when too few corridor results', async () => {
+    const existing: Restaurant[] = [
+      {
+        name: 'Gone',
+        slug: 'gone',
+        website: '',
+        onlineOrderUrl: '',
+        placeId: 'p-gone',
+      },
+    ];
+    const client = fakeClient([place({ placeId: 'only', name: 'Only One' })], {
+      'p-gone': 'CLOSED_PERMANENTLY',
+    });
+    const effects = fakeEffects(existing);
+    const result = await run(client, effects);
+
+    expect(result.aborted).toBe(true);
+    expect(effects.written).toHaveLength(0);
+    expect(effects.deleted).toHaveLength(0);
+    expect(effects.prs).toHaveLength(0);
+  });
+
+  test('removes a permanently closed restaurant and opens a PR', async () => {
+    const existing: Restaurant[] = [
+      {
+        name: 'Gone',
+        slug: 'gone',
+        website: '',
+        onlineOrderUrl: '',
+        placeId: 'p-gone',
+      },
+    ];
+    const client = fakeClient(padPlaces(12), {
+      'p-gone': 'CLOSED_PERMANENTLY',
+    });
+    const effects = fakeEffects(existing);
+    const result = await run(client, effects);
+
+    expect(result.aborted).toBe(false);
+    expect(result.closures).toBe(1);
+    expect(effects.deleted).toContain('src/assets/images/gone.png');
+    expect(effects.prs[0]?.map(r => r.slug)).toEqual(['gone']);
+    expect(effects.written[0]).not.toContain('"gone"');
+  });
+
+  test('filters out-of-corridor discoveries from additions', async () => {
+    const farEast = place({
+      placeId: 'p-far',
+      name: 'Far Away Diner',
+      location: { lat: 38.8276, lng: -77.0641 + 0.01 },
+    });
+    const client = fakeClient([...padPlaces(12), farEast], {});
+    const effects = fakeEffects([]);
+    const result = await run(client, effects);
+
+    // padPlaces are all in-corridor and become additions; farEast must not.
+    expect(effects.issues[0]).not.toContain('Far Away Diner');
+    expect(result.additions).toBe(12);
+  });
+
+  test('always reports an issue', async () => {
+    const client = fakeClient(padPlaces(12), {});
+    const effects = fakeEffects([]);
+    await run(client, effects);
+    expect(effects.issues).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test scripts/check-restaurants/run.test.ts`
+Expected: FAIL with "Cannot find module './run'".
+
+- [ ] **Step 3: Implement the orchestrator**
+
+Create `scripts/check-restaurants/run.ts`:
+
+```ts
+import {
+  CORRIDOR_END_BUFFER_METERS,
+  CORRIDOR_WIDTH_METERS,
+  MIN_EXPECTED_RESULTS,
+  SEGMENT_END,
+  SEGMENT_START,
+} from './config';
+import { diffRestaurants } from './diff';
+import { isWithinCorridor } from './geo';
+import type { PlacesClient } from './places-client';
+import {
+  applyBackfills,
+  applyClosures,
+  buildIssueBody,
+  imageFilesToDelete,
+  serializeRestaurants,
+} from './report';
+import type { BusinessStatus, Restaurant } from './types';
+
+export interface Effects {
+  readRestaurants(): Promise<Restaurant[]>;
+  writeRestaurants(json: string): Promise<void>;
+  deleteImages(paths: string[]): Promise<void>;
+  reportIssue(body: string): Promise<void>;
+  openClosurePr(removed: Restaurant[]): Promise<void>;
+  log(msg: string): void;
+}
+
+export interface RunResult {
+  additions: number;
+  closures: number;
+  backfills: number;
+  warnings: number;
+  aborted: boolean;
+}
+
+export async function run(
+  client: PlacesClient,
+  effects: Effects,
+): Promise<RunResult> {
+  const existing = await effects.readRestaurants();
+
+  const raw = await client.searchNearby();
+  const discovered = raw.filter(p =>
+    isWithinCorridor(
+      p.location,
+      SEGMENT_START,
+      SEGMENT_END,
+      CORRIDOR_WIDTH_METERS,
+      CORRIDOR_END_BUFFER_METERS,
+    ),
+  );
+  effects.log(
+    `Found ${raw.length} raw, ${discovered.length} within corridor.`,
+  );
+
+  if (discovered.length < MIN_EXPECTED_RESULTS) {
+    effects.log(
+      `Only ${discovered.length} corridor results (< ${MIN_EXPECTED_RESULTS}). Aborting without removals.`,
+    );
+    return {
+      additions: 0,
+      closures: 0,
+      backfills: 0,
+      warnings: 0,
+      aborted: true,
+    };
+  }
+
+  const statuses = new Map<string, BusinessStatus | 'NOT_FOUND'>();
+  for (const r of existing) {
+    if (r.placeId) statuses.set(r.placeId, await client.getPlaceStatus(r.placeId));
+  }
+
+  const diff = diffRestaurants(existing, discovered, statuses);
+
+  let next = applyBackfills(existing, diff.backfills);
+  if (diff.closures.length > 0) {
+    next = applyClosures(next, diff.closures);
+  }
+
+  if (diff.backfills.length > 0 || diff.closures.length > 0) {
+    await effects.writeRestaurants(serializeRestaurants(next));
+  }
+  if (diff.closures.length > 0) {
+    await effects.deleteImages(imageFilesToDelete(diff.closures));
+    await effects.openClosurePr(diff.closures);
+  }
+
+  await effects.reportIssue(buildIssueBody(diff.additions, diff.warnings));
+
+  return {
+    additions: diff.additions.length,
+    closures: diff.closures.length,
+    backfills: diff.backfills.length,
+    warnings: diff.warnings.length,
+    aborted: false,
+  };
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test scripts/check-restaurants/run.test.ts`
+Expected: PASS, all run tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/check-restaurants/run.ts scripts/check-restaurants/run.test.ts
+git commit -m "feat: add orchestrator with corridor filter + safety guard"
+```
+
+---
+
+### Task 9: Real effects + entrypoint
+
+**Files:**
+- Create: `scripts/check-restaurants/effects.ts`
+- Create: `scripts/check-restaurants/main.ts`
+
+**Interfaces:**
+- Consumes: `Effects` from `./run`; `Restaurant` from `./types`; `createPlacesClient` from `./places-client`; `run` from `./run`.
+- Produces: `createRealEffects(): Effects`; `main.ts` default executable entrypoint.
+
+These perform real I/O (`node:fs/promises`, `child_process` `gh`), so they are covered by the end-to-end manual verification step rather than unit tests (mocking `gh` and the filesystem here would test the mocks, not behavior).
+
+- [ ] **Step 1: Create the real effects**
+
+Create `scripts/check-restaurants/effects.ts`:
+
+```ts
+import { execFile } from 'node:child_process';
+import { readFile, rm, writeFile } from 'node:fs/promises';
+import { promisify } from 'node:util';
+
+import type { Effects } from './run';
+import type { Restaurant } from './types';
+
+const execFileAsync = promisify(execFile);
+
+const DATA_PATH = 'src/data/restaurants.json';
+const ISSUE_TITLE = 'Restaurant directory check';
+const PR_BRANCH = 'bot/restaurant-closures';
+
+async function gh(args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('gh', args);
+  return stdout.trim();
+}
+
+export function createRealEffects(): Effects {
+  return {
+    async readRestaurants(): Promise<Restaurant[]> {
+      return JSON.parse(await readFile(DATA_PATH, 'utf8')) as Restaurant[];
+    },
+
+    async writeRestaurants(json: string): Promise<void> {
+      await writeFile(DATA_PATH, json, 'utf8');
+    },
+
+    async deleteImages(paths: string[]): Promise<void> {
+      for (const p of paths) await rm(p, { force: true });
+    },
+
+    async reportIssue(body: string): Promise<void> {
+      // Reuse an open issue with our title if present; else create one.
+      const existing = await gh([
+        'issue',
+        'list',
+        '--state',
+        'open',
+        '--search',
+        `${ISSUE_TITLE} in:title`,
+        '--json',
+        'number',
+        '--jq',
+        '.[0].number // empty',
+      ]);
+      if (existing) {
+        await gh(['issue', 'comment', existing, '--body', body]);
+      } else {
+        await gh([
+          'issue',
+          'create',
+          '--title',
+          `${ISSUE_TITLE} (${new Date().toISOString().slice(0, 10)})`,
+          '--body',
+          body,
+        ]);
+      }
+    },
+
+    async openClosurePr(removed: Restaurant[]): Promise<void> {
+      const names = removed.map(r => r.name).join(', ');
+      await execFileAsync('git', ['checkout', '-B', PR_BRANCH]);
+      await execFileAsync('git', ['add', '-A']);
+      await execFileAsync('git', [
+        'commit',
+        '-m',
+        `chore: remove permanently closed restaurants (${names})`,
+      ]);
+      await execFileAsync('git', ['push', '-f', 'origin', PR_BRANCH]);
+      await gh([
+        'pr',
+        'create',
+        '--title',
+        `Remove closed restaurants: ${names}`,
+        '--body',
+        `Auto-detected as CLOSED_PERMANENTLY by the Places API:\n\n${removed
+          .map(r => `- ${r.name} (\`${r.slug}\`)`)
+          .join('\n')}`,
+        '--head',
+        PR_BRANCH,
+      ]);
+    },
+
+    log(msg: string): void {
+      console.log(msg);
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Create the entrypoint**
+
+Create `scripts/check-restaurants/main.ts`:
+
+```ts
+import { createRealEffects } from './effects';
+import { createPlacesClient } from './places-client';
+import { run } from './run';
+
+async function main(): Promise<void> {
+  const apiKey = process.env['GOOGLE_PLACES_API_KEY'];
+  if (!apiKey) {
+    console.error('GOOGLE_PLACES_API_KEY is not set.');
+    process.exit(1);
+  }
+
+  const client = createPlacesClient(apiKey);
+  const effects = createRealEffects();
+  const result = await run(client, effects);
+
+  console.log(JSON.stringify(result));
+  if (result.aborted) process.exit(1);
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 3: Type-check the whole script**
+
+Run: `pnpm exec tsc --noEmit -p tsconfig.json`
+Expected: no errors in `scripts/check-restaurants/`.
+
+- [ ] **Step 4: Run the full test suite**
+
+Run: `pnpm test`
+Expected: PASS, all suites green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/check-restaurants/effects.ts scripts/check-restaurants/main.ts
+git commit -m "feat: add real effects + entrypoint for restaurant check"
+```
+
+---
+
+### Task 10: GitHub Action workflow
+
+**Files:**
+- Create: `.github/workflows/check-restaurants.yml`
+
+**Interfaces:**
+- Consumes: the `check:restaurants` npm script; repo secret `GOOGLE_PLACES_API_KEY`; built-in `GITHUB_TOKEN`.
+- Produces: a scheduled + manually-dispatchable workflow.
+
+- [ ] **Step 1: Create the workflow**
+
+Create `.github/workflows/check-restaurants.yml`:
+
+```yaml
+name: Check restaurants
+
+on:
+  schedule:
+    - cron: '0 13 * * 1' # Mondays 13:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Configure git identity
+        run: |
+          git config user.name "del-ray-eats-bot"
+          git config user.email "bot@users.noreply.github.com"
+
+      - name: Run restaurant check
+        env:
+          GOOGLE_PLACES_API_KEY: ${{ secrets.GOOGLE_PLACES_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: pnpm check:restaurants
+```
+
+- [ ] **Step 2: Validate the YAML parses**
+
+Run: `pnpm exec tsx -e "import {readFileSync} from 'node:fs'; console.log(readFileSync('.github/workflows/check-restaurants.yml','utf8').length>0?'ok':'empty')"`
+Expected: prints `ok` (sanity check the file exists and is readable; GitHub validates schema on push).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/check-restaurants.yml
+git commit -m "ci: add scheduled restaurant check workflow"
+```
+
+---
+
+### Task 11: First live run — backfill placeIds + manual verification
+
+This task is **operational**, run by the human with real credentials. It produces the one-time `placeId` backfill and confirms the corridor/endpoints are calibrated.
+
+**Files:**
+- Modify: `src/data/restaurants.json` (gains `placeId` per entry)
+
+- [ ] **Step 1: Set the API key locally**
+
+```bash
+export GOOGLE_PLACES_API_KEY=your-key-here
+gh auth status   # confirm gh is logged in for issue/PR creation
+```
+
+- [ ] **Step 2: Verify the endpoint coordinates**
+
+Open Google Maps. Confirm `SEGMENT_START` (Mount Vernon Ave ∩ E Braddock Rd) and `SEGMENT_END` (Mount Vernon Ave ∩ Commonwealth Ave) in `config.ts` match the real intersections; adjust if needed and re-run `pnpm test` so geo tests still pass.
+
+- [ ] **Step 3: Dry-run the search to eyeball the corridor**
+
+Run a one-off inspection (no writes) to confirm the corridor captures the known list and excludes neighbors:
+
+```bash
+pnpm exec tsx -e "import {createPlacesClient} from './scripts/check-restaurants/places-client.ts'; import {isWithinCorridor} from './scripts/check-restaurants/geo.ts'; import {SEGMENT_START,SEGMENT_END,CORRIDOR_WIDTH_METERS,CORRIDOR_END_BUFFER_METERS} from './scripts/check-restaurants/config.ts'; const c=createPlacesClient(process.env.GOOGLE_PLACES_API_KEY); const raw=await c.searchNearby(); const inC=raw.filter(p=>isWithinCorridor(p.location,SEGMENT_START,SEGMENT_END,CORRIDOR_WIDTH_METERS,CORRIDOR_END_BUFFER_METERS)); console.log('raw',raw.length,'corridor',inC.length); for(const p of inC) console.log(p.name,'|',p.address);"
+```
+
+Expected: the printed list should contain your known restaurants (Lena's, Junction, Del Ray Café, etc.) and not obvious far-off places. If too greedy/strict, tune `CORRIDOR_WIDTH_METERS` and re-run.
+
+- [ ] **Step 4: Run the real check to backfill placeIds**
+
+```bash
+pnpm check:restaurants
+```
+
+This writes `placeId` onto matched entries in `restaurants.json` (backfills), opens the candidates issue, and opens a closures PR only if something is `CLOSED_PERMANENTLY`.
+
+- [ ] **Step 5: Review the placeId backfill diff**
+
+Run: `git diff src/data/restaurants.json`
+Expected: each existing entry gains a plausible `placeId`. Manually resolve any entry that did NOT get one (look it up in Maps, add the `placeId` by hand). Verify the candidates issue and any closures PR look correct.
+
+- [ ] **Step 6: Commit the backfill**
+
+```bash
+git add src/data/restaurants.json
+git commit -m "data: backfill Google placeId for existing restaurants"
+```
+
+- [ ] **Step 7: Confirm the production build still works**
+
+Run: `pnpm build`
+Expected: build succeeds (the added `placeId` field does not affect `card.astro` or image resolution).
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** data source (Task 6), corridor geo incl. one-block east/west (Task 3 + config Task 4), `placeId` schema + backfill (Tasks 2, 5, 8, 11), closures→PR (Tasks 7–9), additions→Issue with auto-filled website (Tasks 7, 9), safety guards / min-results abort & `CLOSED_PERMANENTLY`-only removal (Tasks 5, 8), idempotent issue/PR (Task 9), vitest pure-core tests + mocked client (Tasks 1, 3, 5, 6, 7, 8), scheduled Action (Task 10), cost (no task needed — inherent). All spec sections map to a task.
+- **Type consistency:** `Restaurant`, `DiscoveredPlace`, `LatLng`, `BusinessStatus` defined once in Task 2 and imported everywhere; `Effects`/`RunResult`/`PlacesClient`/`DiffResult` signatures match across Tasks 6, 8, 9.
+- **Known limitations (documented, acceptable):** Nearby Search `maxResultCount` caps at 20; endpoint coords are approximate and verified in Task 11.

--- a/docs/superpowers/specs/2026-06-26-restaurant-discovery-automation-design.md
+++ b/docs/superpowers/specs/2026-06-26-restaurant-discovery-automation-design.md
@@ -1,0 +1,128 @@
+# Restaurant Discovery Automation — Design
+
+**Date:** 2026-06-26
+**Status:** Approved (design phase)
+
+## Problem
+
+`src/data/restaurants.json` is the single source of truth for Del Ray Eats, but it
+is maintained by hand. The original list was collected by manually browsing Google
+Maps for restaurants on the Mount Vernon Avenue strip in Del Ray, Alexandria VA,
+between Braddock Road (south) and Commonwealth Avenue (north). The list drifts out
+of date as restaurants open and close.
+
+**Goal:** Automatically detect when a restaurant should be *added* (newly opened) or
+*removed* (permanently closed) on this strip. Detection is the primary value;
+full hands-off automation is desirable where it is safe.
+
+## Scope & Priorities
+
+- **Most important:** reliably knowing when to add a new restaurant or remove a closed one.
+- **Closures** can be fully automated — removing a closed restaurant needs no manual enrichment.
+- **Additions** inherently need a human touch: the `onlineOrderUrl` and the per-restaurant
+  image cannot be sourced automatically. The Google-provided website *can* be auto-filled.
+
+## Data Source
+
+**Google Places API (New).** Chosen because its `business_status` field
+(`OPERATIONAL` / `CLOSED_TEMPORARILY` / `CLOSED_PERMANENTLY`) directly answers the
+"did it close?" question, and Nearby Search lets us query by location. Requires a
+Google Cloud account with billing enabled; expected real cost is ~$0 given the tiny
+query volume (well within the monthly free credit).
+
+## Architecture
+
+A single Node script (matches the existing pnpm/Node toolchain), executed by a
+**scheduled GitHub Action** (weekly cron + manual `workflow_dispatch`). The API key
+is stored in the repo secret `GOOGLE_PLACES_API_KEY`.
+
+Each run:
+
+1. **Fetch** current restaurants on the strip via Places **Nearby Search (New)**.
+2. **Load** `src/data/restaurants.json`.
+3. **Diff** the two sets by stable identity (`placeId`).
+4. **Act** — open a PR for confirmed closures; open/update an Issue for new candidates.
+
+The script is structured into three parts to isolate I/O from logic:
+
+- **Places client** — the only part that touches the network; mockable in tests.
+- **Pure diff/filter core** — no I/O. Corridor filtering, diffing, slug generation.
+  Fully unit-testable.
+- **Reporter** — writes the PR / Issue via the `gh` CLI or GitHub API.
+
+## Geographic Scope — Corridor Filter
+
+The strip is a line segment, not a circle, and must also include businesses up to
+roughly one block east or west of the Avenue (e.g., Del Ray Café, which is just off
+Mount Vernon Ave but belongs on the list).
+
+Approach:
+
+1. Geocode the two bounding intersections once: Braddock Rd ∩ Mount Vernon Ave (south
+   endpoint) and Commonwealth Ave ∩ Mount Vernon Ave (north endpoint). These define a
+   line segment.
+2. Run Nearby Search over a circle that covers the whole strip, with a **broad type
+   filter** (restaurant, cafe, bakery, coffee shop, bar, meal takeaway/delivery, etc.)
+   — the existing list includes a bakery, a coffee pub, and a cheese shop.
+3. **Keep** a result only if:
+   - its **perpendicular distance to the segment is ≤ ~150m** (~one block), **and**
+   - its **projection onto the segment falls between the two endpoints** (plus a small
+     buffer at each end).
+
+This is pure geometry (point-to-segment distance) — no address string matching — so it
+is fully unit-testable. The corridor width and end buffer are **tunable constants** so
+the filter can be widened or narrowed after observing the first run.
+
+## Stable Identity — `placeId` Schema Addition
+
+Matching JSON entries to Google results via fuzzy name matching is fragile (re-flagging
+the same place as "new," or missing a closure). Instead, add a **`placeId`** field to
+each entry in `restaurants.json` — Google's permanent business identifier.
+
+- Closure detection becomes exact: query that `placeId`'s `business_status` directly.
+- Duplicate "new" flags are prevented: a discovered place whose `placeId` is already in
+  the data is not new.
+- The change is **purely additive** — `card.astro` only consumes
+  `name`/`slug`/`website`/`onlineOrderUrl` + the image, so nothing else changes.
+
+**One-time backfill:** the first run fuzzy-matches each existing restaurant to its
+`placeId` and proposes the assignments via a PR for human confirmation. After that,
+`placeId` is the matching key.
+
+## Outputs & Safety Guards
+
+**Closures → Pull Request.** For each existing restaurant whose `placeId` reports
+`business_status: CLOSED_PERMANENTLY`, the PR removes its entry from
+`restaurants.json` and deletes its `src/assets/images/<slug>.png`. The PR body lists
+each removal and the reason.
+
+**New candidates → Issue.** Opens (or updates) a single issue listing each newly
+discovered place with: name, address, Google-provided `website`, a Google Maps link,
+the `placeId`, and a suggested `slug`. The human finishes `onlineOrderUrl` + image.
+
+**Safety guards** (a bad API response must not destroy data):
+
+- If the search returns 0 or implausibly few results, **abort** without proposing any
+  removals.
+- Only `CLOSED_PERMANENTLY` triggers removal. `CLOSED_TEMPORARILY`, or a place silently
+  dropping out of results while still `OPERATIONAL`, is **reported in the issue, not
+  auto-removed**.
+- Issue/PR creation is **idempotent** — reuse the open issue / existing branch rather
+  than stacking duplicates each week.
+
+## Testing
+
+- **Pure core** (corridor filter, diffing, slug generation) gets unit tests with fixture
+  data via **vitest**. The project currently has no test setup; a minimal one is added.
+- The Places client is **mocked** in tests — no live API calls in CI.
+
+## Cost
+
+~30 places, one Nearby Search plus a handful of Place Details calls, run weekly.
+Comfortably within Google's monthly free credit — effectively $0.
+
+## Out of Scope
+
+- Automatic sourcing of `onlineOrderUrl` and per-restaurant images.
+- Detecting changes other than open/close (e.g., renamed or relocated businesses) beyond
+  what `placeId` + the new-candidate issue naturally surfaces.

--- a/package.json
+++ b/package.json
@@ -10,17 +10,22 @@
     "start": "astro dev",
     "build": "astro build && pnpm generateSW",
     "generateSW": "SW_DIST_PATH=dist/ workbox generateSW workbox.config.cjs",
-    "preview": "astro preview"
+    "preview": "astro preview",
+    "test": "vitest run",
+    "check:restaurants": "tsx scripts/check-restaurants/main.ts"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
     "@tailwindcss/vite": "^4.3.1",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
+    "@types/node": "^26.0.1",
     "astro": "^7.0.2",
     "prettier": "^3.8.4",
     "prettier-plugin-astro": "^0.14.1",
     "tailwindcss": "^4.3.1",
+    "tsx": "^4.22.4",
     "typescript": "^6.0.3",
+    "vitest": "^4.1.9",
     "workbox-cli": "^7.4.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,13 +13,16 @@ importers:
         version: 0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.8.4)(typescript@6.0.3)
       '@tailwindcss/vite':
         specifier: ^4.3.1
-        version: 4.3.1(vite@8.1.0(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+        version: 4.3.1(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^6.0.2
         version: 6.0.2(prettier@3.8.4)
+      '@types/node':
+        specifier: ^26.0.1
+        version: 26.0.1
       astro:
         specifier: ^7.0.2
-        version: 7.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(jiti@2.7.0)(rollup@4.62.2)(terser@5.48.0)(yaml@2.9.0)
+        version: 7.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.1)(jiti@2.7.0)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       prettier:
         specifier: ^3.8.4
         version: 3.8.4
@@ -29,9 +32,15 @@ importers:
       tailwindcss:
         specifier: ^4.3.1
         version: 4.3.1
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@26.0.1)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       workbox-cli:
         specifier: ^7.4.1
         version: 7.4.1
@@ -1410,6 +1419,9 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tailwindcss/node@4.3.1':
     resolution: {integrity: sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==}
 
@@ -1530,6 +1542,12 @@ packages:
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -1548,6 +1566,9 @@ packages:
   '@types/nlcst@2.0.3':
     resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
 
+  '@types/node@26.0.1':
+    resolution: {integrity: sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==}
+
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
@@ -1562,6 +1583,35 @@ packages:
 
   '@ungap/structured-clone@1.3.2':
     resolution: {integrity: sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==}
+
+  '@vitest/expect@4.1.9':
+    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
+
+  '@vitest/mocker@4.1.9':
+    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.9':
+    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
+
+  '@vitest/runner@4.1.9':
+    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
+
+  '@vitest/snapshot@4.1.9':
+    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
+
+  '@vitest/spy@4.1.9':
+    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
+
+  '@vitest/utils@4.1.9':
+    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
 
   '@volar/kit@2.4.28':
     resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
@@ -1654,6 +1704,10 @@ packages:
   arrify@1.0.1:
     resolution: {integrity: sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==}
     engines: {node: '>=0.10.0'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   astro@7.0.2:
     resolution: {integrity: sha512-Rj31HS85pVSfiQTxKTwH6vTmF8y57iRfkgb1uiCTtdLIh3jlUKPAPXtEmHXRKp/PdTS00D4EXYlWXypY+AVVCA==}
@@ -1785,6 +1839,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -2102,6 +2160,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -2112,6 +2173,10 @@ packages:
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -2960,6 +3025,9 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   piccolore@0.1.3:
     resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
 
@@ -3247,6 +3315,9 @@ packages:
     resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -3295,6 +3366,12 @@ packages:
 
   spdx-license-ids@3.0.23:
     resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
@@ -3402,6 +3479,9 @@ packages:
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyclip@0.1.15:
     resolution: {integrity: sha512-uo33abH+Ays0xYaDysoBt494Hb3hsEczMpcC0MwFl773pazORx4fmvKhclhR1wonUbB6vvpRsvVMwnhfqeMc+A==}
     engines: {node: ^16.14.0 || >= 17.3.0}
@@ -3413,6 +3493,10 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
@@ -3440,6 +3524,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
@@ -3504,6 +3593,9 @@ packages:
 
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -3692,6 +3784,47 @@ packages:
       vite:
         optional: true
 
+  vitest@4.1.9:
+    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.9
+      '@vitest/browser-preview': 4.1.9
+      '@vitest/browser-webdriverio': 4.1.9
+      '@vitest/coverage-istanbul': 4.1.9
+      '@vitest/coverage-v8': 4.1.9
+      '@vitest/ui': 4.1.9
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   volar-service-css@0.0.70:
     resolution: {integrity: sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw==}
     peerDependencies:
@@ -3832,6 +3965,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   widest-line@5.0.0:
@@ -5271,6 +5409,8 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tailwindcss/node@4.3.1':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -5332,12 +5472,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
 
-  '@tailwindcss/vite@4.3.1(vite@8.1.0(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.3.1(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
-      vite: 8.1.0(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@trickfilm400/rollup-plugin-off-main-thread@3.0.0-pre1':
     dependencies:
@@ -5365,6 +5505,13 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree-jsx@1.0.5':
     dependencies:
       '@types/estree': 1.0.9
@@ -5385,6 +5532,10 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/node@26.0.1':
+    dependencies:
+      undici-types: 8.3.0
+
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/resolve@1.20.2': {}
@@ -5394,6 +5545,47 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.2': {}
+
+  '@vitest/expect@4.1.9':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.9(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.9':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.9':
+    dependencies:
+      '@vitest/utils': 4.1.9
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/utils': 4.1.9
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.9': {}
+
+  '@vitest/utils@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@volar/kit@2.4.28(typescript@6.0.3)':
     dependencies:
@@ -5506,7 +5698,9 @@ snapshots:
 
   arrify@1.0.1: {}
 
-  astro@7.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(jiti@2.7.0)(rollup@4.62.2)(terser@5.48.0)(yaml@2.9.0):
+  assertion-error@2.0.1: {}
+
+  astro@7.0.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.1)(jiti@2.7.0)(rollup@4.62.2)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler-rs': 0.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@astrojs/internal-helpers': 0.10.0
@@ -5559,8 +5753,8 @@ snapshots:
       unist-util-visit: 5.1.0
       unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 8.1.0(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@8.1.0(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))
+      vite: 8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
       zod: 4.4.3
@@ -5730,6 +5924,8 @@ snapshots:
   caniuse-lite@1.0.30001799: {}
 
   ccount@2.0.1: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -6109,11 +6305,17 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   eta@4.6.0: {}
 
   eventemitter3@5.0.4: {}
+
+  expect-type@1.4.0: {}
 
   extend@3.0.2: {}
 
@@ -6937,6 +7139,8 @@ snapshots:
       lru-cache: 11.5.1
       minipass: 7.1.3
 
+  pathe@2.0.3: {}
+
   piccolore@0.1.3: {}
 
   picocolors@1.1.1: {}
@@ -7339,6 +7543,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -7377,6 +7583,10 @@ snapshots:
       spdx-license-ids: 3.0.23
 
   spdx-license-ids@3.0.23: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -7516,6 +7726,8 @@ snapshots:
 
   tiny-inflate@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
   tinyclip@0.1.15: {}
 
   tinyexec@1.2.4: {}
@@ -7524,6 +7736,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   tmp@0.0.33:
     dependencies:
@@ -7547,6 +7761,12 @@ snapshots:
 
   tslib@2.8.1:
     optional: true
+
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-fest@0.13.1: {}
 
@@ -7613,6 +7833,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   uncrypto@0.1.3: {}
+
+  undici-types@8.3.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -7724,7 +7946,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@8.1.0(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0):
+  vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -7732,15 +7954,44 @@ snapshots:
       rolldown: 1.1.3
       tinyglobby: 0.2.17
     optionalDependencies:
+      '@types/node': 26.0.1
       esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0
       terser: 5.48.0
+      tsx: 4.22.4
       yaml: 2.9.0
 
-  vitefu@1.1.3(vite@8.1.0(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)):
+  vitefu@1.1.3(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 8.1.0(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
+      vite: 8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+
+  vitest@4.1.9(@types/node@26.0.1)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.1.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 26.0.1
+    transitivePeerDependencies:
+      - msw
 
   volar-service-css@0.0.70(@volar/language-service@2.4.28):
     dependencies:
@@ -7910,6 +8161,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   widest-line@5.0.0:
     dependencies:

--- a/scripts/check-restaurants/config.ts
+++ b/scripts/check-restaurants/config.ts
@@ -1,0 +1,33 @@
+import type { LatLng } from './types';
+
+// Mount Vernon Ave ∩ E Braddock Rd (south end of the strip). Verify in Maps.
+export const SEGMENT_START: LatLng = { lat: 38.8204, lng: -77.061 };
+
+// Mount Vernon Ave ∩ Commonwealth Ave (north end of the strip). Verify in Maps.
+export const SEGMENT_END: LatLng = { lat: 38.8348, lng: -77.0672 };
+
+// Center and radius of the Nearby Search circle covering the whole strip.
+export const SEARCH_CENTER: LatLng = { lat: 38.8276, lng: -77.0641 };
+export const SEARCH_RADIUS_METERS = 1200;
+
+// Corridor: keep places within this perpendicular distance of the avenue line,
+// extended slightly past each endpoint. ~150 m ≈ one block east/west.
+export const CORRIDOR_WIDTH_METERS = 150;
+export const CORRIDOR_END_BUFFER_METERS = 50;
+
+// Abort and propose no removals if fewer than this many corridor matches return.
+export const MIN_EXPECTED_RESULTS = 10;
+
+// Broad type filter — the list includes a bakery, a coffee pub, a cheese shop.
+export const INCLUDED_TYPES: readonly string[] = [
+  'restaurant',
+  'cafe',
+  'coffee_shop',
+  'bakery',
+  'bar',
+  'meal_takeaway',
+  'meal_delivery',
+  'ice_cream_shop',
+  'sandwich_shop',
+  'pizza_restaurant',
+];

--- a/scripts/check-restaurants/config.ts
+++ b/scripts/check-restaurants/config.ts
@@ -6,16 +6,23 @@ export const SEGMENT_START: LatLng = { lat: 38.8204, lng: -77.061 };
 // Mount Vernon Ave ∩ Commonwealth Ave (north end of the strip). Verify in Maps.
 export const SEGMENT_END: LatLng = { lat: 38.8348, lng: -77.0672 };
 
-// Center and radius of the Nearby Search circle covering the whole strip.
-export const SEARCH_CENTER: LatLng = { lat: 38.8276, lng: -77.0641 };
-export const SEARCH_RADIUS_METERS = 1200;
+// Nearby Search (New) caps each request at 20 results with no pagination, so
+// we tile a series of small overlapping circles along the corridor and union
+// their results by placeId instead of issuing one big-radius search.
+export const SEARCH_TILE_SPACING_METERS = 200;
+export const SEARCH_TILE_RADIUS_METERS = 250;
+export const SEARCH_TILE_EXTEND_METERS = 50;
 
 // Corridor: keep places within this perpendicular distance of the avenue line,
 // extended slightly past each endpoint. ~150 m ≈ one block east/west.
 export const CORRIDOR_WIDTH_METERS = 150;
 export const CORRIDOR_END_BUFFER_METERS = 50;
 
-// Abort and propose no removals if fewer than this many corridor matches return.
+// Abort and propose no removals if fewer than this many corridor matches
+// return. With tiling, the strip has ~29 known restaurants, so a healthy run
+// should find close to that many; fewer than 10 signals an API problem
+// (e.g. a bad key, quota, or broken tiling) rather than a genuinely quiet
+// corridor.
 export const MIN_EXPECTED_RESULTS = 10;
 
 // Broad type filter — the list includes a bakery, a coffee pub, a cheese shop.

--- a/scripts/check-restaurants/diff.test.ts
+++ b/scripts/check-restaurants/diff.test.ts
@@ -47,6 +47,16 @@ describe('nameSimilarity', () => {
   test('unrelated names score below threshold', () => {
     expect(nameSimilarity('Thai Peppers', 'Pork Barrel BBQ')).toBeLessThan(0.6);
   });
+
+  test('names that reduce to empty token sets score 0, not a perfect match', () => {
+    expect(nameSimilarity('the and of', 'the of and')).toBe(0);
+  });
+
+  test('names sharing only a generic stopword score below threshold', () => {
+    expect(
+      nameSimilarity('Del Ray Pizzeria', 'Holy Cow'),
+    ).toBeLessThan(0.6);
+  });
 });
 
 describe('diffRestaurants', () => {

--- a/scripts/check-restaurants/diff.test.ts
+++ b/scripts/check-restaurants/diff.test.ts
@@ -53,9 +53,7 @@ describe('nameSimilarity', () => {
   });
 
   test('names sharing only a generic stopword score below threshold', () => {
-    expect(
-      nameSimilarity('Del Ray Pizzeria', 'Holy Cow'),
-    ).toBeLessThan(0.6);
+    expect(nameSimilarity('Del Ray Pizzeria', 'Holy Cow')).toBeLessThan(0.6);
   });
 });
 
@@ -85,11 +83,15 @@ describe('diffRestaurants', () => {
   });
 
   test('backfills placeId for an existing entry with no placeId via name match', () => {
-    const existing = [restaurant({ name: 'Thai Peppers', slug: 'thai-peppers' })];
+    const existing = [
+      restaurant({ name: 'Thai Peppers', slug: 'thai-peppers' }),
+    ];
     const discovered = [place({ placeId: 'p-thai', name: 'Thai Peppers' })];
     const statuses = new Map<string, BusinessStatus | 'NOT_FOUND'>();
     const result = diffRestaurants(existing, discovered, statuses);
-    expect(result.backfills).toEqual([{ slug: 'thai-peppers', placeId: 'p-thai' }]);
+    expect(result.backfills).toEqual([
+      { slug: 'thai-peppers', placeId: 'p-thai' },
+    ]);
     // matched by name, so NOT an addition
     expect(result.additions).toEqual([]);
   });

--- a/scripts/check-restaurants/diff.test.ts
+++ b/scripts/check-restaurants/diff.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'vitest';
+
+import { diffRestaurants, nameSimilarity, slugify } from './diff';
+import type { BusinessStatus, DiscoveredPlace, Restaurant } from './types';
+
+const place = (over: Partial<DiscoveredPlace>): DiscoveredPlace => ({
+  placeId: 'p-default',
+  name: 'Some Place',
+  location: { lat: 38.8276, lng: -77.0641 },
+  address: '123 Mount Vernon Ave',
+  website: null,
+  businessStatus: 'OPERATIONAL',
+  ...over,
+});
+
+const restaurant = (over: Partial<Restaurant>): Restaurant => ({
+  name: 'Some Place',
+  slug: 'some-place',
+  website: 'https://example.com',
+  onlineOrderUrl: 'https://example.com/order',
+  ...over,
+});
+
+describe('slugify', () => {
+  test('lowercases, strips punctuation, hyphenates', () => {
+    expect(slugify("Matt & Tony's All Day Kitchen + Bar")).toBe(
+      'matt-tonys-all-day-kitchen-bar',
+    );
+  });
+
+  test('collapses repeated separators and trims', () => {
+    expect(slugify('  Hi/Fi  Tex-Mex  BBQ ')).toBe('hifi-tex-mex-bbq');
+  });
+});
+
+describe('nameSimilarity', () => {
+  test('identical names score 1', () => {
+    expect(nameSimilarity('Thai Peppers', 'Thai Peppers')).toBe(1);
+  });
+
+  test('related names score above the 0.6 threshold', () => {
+    expect(
+      nameSimilarity('Del Ray Cafe', 'Del Ray Café Restaurant'),
+    ).toBeGreaterThanOrEqual(0.6);
+  });
+
+  test('unrelated names score below threshold', () => {
+    expect(nameSimilarity('Thai Peppers', 'Pork Barrel BBQ')).toBeLessThan(0.6);
+  });
+});
+
+describe('diffRestaurants', () => {
+  test('flags a permanently closed existing restaurant as a closure', () => {
+    const existing = [restaurant({ slug: 'gone', placeId: 'p-gone' })];
+    const statuses = new Map<string, BusinessStatus | 'NOT_FOUND'>([
+      ['p-gone', 'CLOSED_PERMANENTLY'],
+    ]);
+    const result = diffRestaurants(existing, [], statuses);
+    expect(result.closures.map(r => r.slug)).toEqual(['gone']);
+    expect(result.additions).toEqual([]);
+  });
+
+  test('flags an unknown discovered place as an addition', () => {
+    const existing = [restaurant({ slug: 'keep', placeId: 'p-keep' })];
+    const discovered = [
+      place({ placeId: 'p-keep', name: 'Keep' }),
+      place({ placeId: 'p-new', name: 'Brand New Spot' }),
+    ];
+    const statuses = new Map<string, BusinessStatus | 'NOT_FOUND'>([
+      ['p-keep', 'OPERATIONAL'],
+    ]);
+    const result = diffRestaurants(existing, discovered, statuses);
+    expect(result.additions.map(p => p.placeId)).toEqual(['p-new']);
+    expect(result.closures).toEqual([]);
+  });
+
+  test('backfills placeId for an existing entry with no placeId via name match', () => {
+    const existing = [restaurant({ name: 'Thai Peppers', slug: 'thai-peppers' })];
+    const discovered = [place({ placeId: 'p-thai', name: 'Thai Peppers' })];
+    const statuses = new Map<string, BusinessStatus | 'NOT_FOUND'>();
+    const result = diffRestaurants(existing, discovered, statuses);
+    expect(result.backfills).toEqual([{ slug: 'thai-peppers', placeId: 'p-thai' }]);
+    // matched by name, so NOT an addition
+    expect(result.additions).toEqual([]);
+  });
+
+  test('warns on temporarily closed and on dropped-out operational entries', () => {
+    const existing = [
+      restaurant({ slug: 'temp', placeId: 'p-temp' }),
+      restaurant({ slug: 'dropped', placeId: 'p-dropped' }),
+    ];
+    const statuses = new Map<string, BusinessStatus | 'NOT_FOUND'>([
+      ['p-temp', 'CLOSED_TEMPORARILY'],
+      ['p-dropped', 'OPERATIONAL'],
+    ]);
+    // p-dropped is operational but not in discovered list
+    const result = diffRestaurants(existing, [], statuses);
+    expect(result.closures).toEqual([]);
+    expect(result.warnings.some(w => w.includes('temp'))).toBe(true);
+    expect(result.warnings.some(w => w.includes('dropped'))).toBe(true);
+  });
+});

--- a/scripts/check-restaurants/diff.ts
+++ b/scripts/check-restaurants/diff.ts
@@ -1,8 +1,4 @@
-import type {
-  BusinessStatus,
-  DiscoveredPlace,
-  Restaurant,
-} from './types';
+import type { BusinessStatus, DiscoveredPlace, Restaurant } from './types';
 
 const NAME_MATCH_THRESHOLD = 0.6;
 

--- a/scripts/check-restaurants/diff.ts
+++ b/scripts/check-restaurants/diff.ts
@@ -6,16 +6,7 @@ import type {
 
 const NAME_MATCH_THRESHOLD = 0.6;
 
-const STOPWORDS = new Set([
-  'the',
-  'restaurant',
-  'cafe',
-  'and',
-  'of',
-  'del',
-  'ray',
-  'va',
-]);
+const STOPWORDS = new Set(['the', 'and', 'of']);
 
 export function slugify(name: string): string {
   return name
@@ -48,7 +39,7 @@ function tokens(name: string): Set<string> {
 export function nameSimilarity(a: string, b: string): number {
   const ta = tokens(a);
   const tb = tokens(b);
-  if (ta.size === 0 && tb.size === 0) return 1;
+  if (ta.size === 0 && tb.size === 0) return 0;
   if (ta.size === 0 || tb.size === 0) return 0;
   let intersection = 0;
   for (const t of ta) if (tb.has(t)) intersection += 1;

--- a/scripts/check-restaurants/diff.ts
+++ b/scripts/check-restaurants/diff.ts
@@ -1,0 +1,131 @@
+import type {
+  BusinessStatus,
+  DiscoveredPlace,
+  Restaurant,
+} from './types';
+
+const NAME_MATCH_THRESHOLD = 0.6;
+
+const STOPWORDS = new Set([
+  'the',
+  'restaurant',
+  'cafe',
+  'and',
+  'of',
+  'del',
+  'ray',
+  'va',
+]);
+
+export function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/[\s-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function normalizeName(name: string): string {
+  return name
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function tokens(name: string): Set<string> {
+  return new Set(
+    normalizeName(name)
+      .split(' ')
+      .filter(t => t.length > 0 && !STOPWORDS.has(t)),
+  );
+}
+
+export function nameSimilarity(a: string, b: string): number {
+  const ta = tokens(a);
+  const tb = tokens(b);
+  if (ta.size === 0 && tb.size === 0) return 1;
+  if (ta.size === 0 || tb.size === 0) return 0;
+  let intersection = 0;
+  for (const t of ta) if (tb.has(t)) intersection += 1;
+  const union = ta.size + tb.size - intersection;
+  return intersection / union;
+}
+
+export interface DiffResult {
+  additions: DiscoveredPlace[];
+  closures: Restaurant[];
+  backfills: Array<{ slug: string; placeId: string }>;
+  warnings: string[];
+}
+
+export function diffRestaurants(
+  existing: Restaurant[],
+  discovered: DiscoveredPlace[],
+  existingStatuses: Map<string, BusinessStatus | 'NOT_FOUND'>,
+): DiffResult {
+  const result: DiffResult = {
+    additions: [],
+    closures: [],
+    backfills: [],
+    warnings: [],
+  };
+
+  const knownPlaceIds = new Set(
+    existing.map(r => r.placeId).filter((id): id is string => Boolean(id)),
+  );
+  const matchedDiscoveredIds = new Set<string>();
+
+  // Backfill placeIds for existing entries that lack one, via name match.
+  for (const r of existing) {
+    if (r.placeId) continue;
+    let best: { place: DiscoveredPlace; score: number } | null = null;
+    for (const d of discovered) {
+      const score = nameSimilarity(r.name, d.name);
+      if (!best || score > best.score) best = { place: d, score };
+    }
+    if (best && best.score >= NAME_MATCH_THRESHOLD) {
+      result.backfills.push({ slug: r.slug, placeId: best.place.placeId });
+      knownPlaceIds.add(best.place.placeId);
+      matchedDiscoveredIds.add(best.place.placeId);
+    }
+  }
+
+  // Closures + warnings, driven by status of existing entries.
+  for (const r of existing) {
+    if (!r.placeId) continue;
+    const status = existingStatuses.get(r.placeId);
+    if (status === 'CLOSED_PERMANENTLY') {
+      result.closures.push(r);
+    } else if (status === 'CLOSED_TEMPORARILY') {
+      result.warnings.push(
+        `${r.slug}: reported CLOSED_TEMPORARILY — not removing, verify manually.`,
+      );
+    } else if (status === 'NOT_FOUND') {
+      result.warnings.push(
+        `${r.slug}: placeId ${r.placeId} not found by Places — verify manually.`,
+      );
+    } else if (!discovered.some(d => d.placeId === r.placeId)) {
+      result.warnings.push(
+        `${r.slug}: operational but absent from corridor search — verify it has not moved.`,
+      );
+    }
+  }
+
+  // Additions: discovered places not known and not name-matched to existing.
+  for (const d of discovered) {
+    if (knownPlaceIds.has(d.placeId) || matchedDiscoveredIds.has(d.placeId)) {
+      continue;
+    }
+    const nameMatch = existing.some(
+      r => nameSimilarity(r.name, d.name) >= NAME_MATCH_THRESHOLD,
+    );
+    if (!nameMatch) result.additions.push(d);
+  }
+
+  return result;
+}

--- a/scripts/check-restaurants/effects.ts
+++ b/scripts/check-restaurants/effects.ts
@@ -2,6 +2,7 @@ import { execFile } from 'node:child_process';
 import { readFile, rm, writeFile } from 'node:fs/promises';
 import { promisify } from 'node:util';
 
+import { imageFilesToDelete } from './report';
 import type { Effects } from './run';
 import type { Restaurant } from './types';
 
@@ -9,11 +10,29 @@ const execFileAsync = promisify(execFile);
 
 const DATA_PATH = 'src/data/restaurants.json';
 const ISSUE_TITLE = 'Restaurant directory check';
-const PR_BRANCH = 'bot/restaurant-closures';
+
+function todayDateSuffix(): string {
+  return new Date().toISOString().slice(0, 10);
+}
 
 async function gh(args: string[]): Promise<string> {
   const { stdout } = await execFileAsync('gh', args);
   return stdout.trim();
+}
+
+async function findOpenPrNumber(branch: string): Promise<string> {
+  return gh([
+    'pr',
+    'list',
+    '--head',
+    branch,
+    '--state',
+    'open',
+    '--json',
+    'number',
+    '--jq',
+    '.[0].number // empty',
+  ]);
 }
 
 export function createRealEffects(): Effects {
@@ -45,7 +64,7 @@ export function createRealEffects(): Effects {
         '.[0].number // empty',
       ]);
       if (existing) {
-        await gh(['issue', 'comment', existing, '--body', body]);
+        await gh(['issue', 'edit', existing, '--body', body]);
       } else {
         await gh([
           'issue',
@@ -60,26 +79,71 @@ export function createRealEffects(): Effects {
 
     async openClosurePr(removed: Restaurant[]): Promise<void> {
       const names = removed.map(r => r.name).join(', ');
-      await execFileAsync('git', ['checkout', '-B', PR_BRANCH]);
-      await execFileAsync('git', ['add', '-A']);
+      const branch = `bot/restaurant-closures-${todayDateSuffix()}`;
+      const imagePaths = imageFilesToDelete(removed);
+      await execFileAsync('git', ['checkout', '-B', branch]);
+      await execFileAsync('git', ['add', '--', DATA_PATH, ...imagePaths]);
       await execFileAsync('git', [
         'commit',
         '-m',
         `chore: remove permanently closed restaurants (${names})`,
       ]);
-      await execFileAsync('git', ['push', '-f', 'origin', PR_BRANCH]);
-      await gh([
-        'pr',
-        'create',
-        '--title',
-        `Remove closed restaurants: ${names}`,
-        '--body',
-        `Auto-detected as CLOSED_PERMANENTLY by the Places API:\n\n${removed
-          .map(r => `- ${r.name} (\`${r.slug}\`)`)
-          .join('\n')}`,
-        '--head',
-        PR_BRANCH,
+      await execFileAsync('git', [
+        'push',
+        '--force-with-lease',
+        'origin',
+        branch,
       ]);
+      const existingPr = await findOpenPrNumber(branch);
+      if (!existingPr) {
+        await gh([
+          'pr',
+          'create',
+          '--title',
+          `Remove closed restaurants: ${names}`,
+          '--body',
+          `Auto-detected as CLOSED_PERMANENTLY by the Places API:\n\n${removed
+            .map(r => `- ${r.name} (\`${r.slug}\`)`)
+            .join('\n')}`,
+          '--head',
+          branch,
+        ]);
+      }
+    },
+
+    async openBackfillPr(
+      backfills: Array<{ slug: string; placeId: string }>,
+    ): Promise<void> {
+      const slugs = backfills.map(b => b.slug).join(', ');
+      const branch = `bot/restaurant-backfills-${todayDateSuffix()}`;
+      await execFileAsync('git', ['checkout', '-B', branch]);
+      await execFileAsync('git', ['add', '--', DATA_PATH]);
+      await execFileAsync('git', [
+        'commit',
+        '-m',
+        `chore: backfill Google placeId for restaurants (${slugs})`,
+      ]);
+      await execFileAsync('git', [
+        'push',
+        '--force-with-lease',
+        'origin',
+        branch,
+      ]);
+      const existingPr = await findOpenPrNumber(branch);
+      if (!existingPr) {
+        await gh([
+          'pr',
+          'create',
+          '--title',
+          `Backfill placeId for restaurants: ${slugs}`,
+          '--body',
+          `Auto-matched to a Google Places result by name similarity:\n\n${backfills
+            .map(b => `- \`${b.slug}\` → placeId \`${b.placeId}\``)
+            .join('\n')}`,
+          '--head',
+          branch,
+        ]);
+      }
     },
 
     log(msg: string): void {

--- a/scripts/check-restaurants/effects.ts
+++ b/scripts/check-restaurants/effects.ts
@@ -1,0 +1,89 @@
+import { execFile } from 'node:child_process';
+import { readFile, rm, writeFile } from 'node:fs/promises';
+import { promisify } from 'node:util';
+
+import type { Effects } from './run';
+import type { Restaurant } from './types';
+
+const execFileAsync = promisify(execFile);
+
+const DATA_PATH = 'src/data/restaurants.json';
+const ISSUE_TITLE = 'Restaurant directory check';
+const PR_BRANCH = 'bot/restaurant-closures';
+
+async function gh(args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('gh', args);
+  return stdout.trim();
+}
+
+export function createRealEffects(): Effects {
+  return {
+    async readRestaurants(): Promise<Restaurant[]> {
+      return JSON.parse(await readFile(DATA_PATH, 'utf8')) as Restaurant[];
+    },
+
+    async writeRestaurants(json: string): Promise<void> {
+      await writeFile(DATA_PATH, json, 'utf8');
+    },
+
+    async deleteImages(paths: string[]): Promise<void> {
+      for (const p of paths) await rm(p, { force: true });
+    },
+
+    async reportIssue(body: string): Promise<void> {
+      // Reuse an open issue with our title if present; else create one.
+      const existing = await gh([
+        'issue',
+        'list',
+        '--state',
+        'open',
+        '--search',
+        `${ISSUE_TITLE} in:title`,
+        '--json',
+        'number',
+        '--jq',
+        '.[0].number // empty',
+      ]);
+      if (existing) {
+        await gh(['issue', 'comment', existing, '--body', body]);
+      } else {
+        await gh([
+          'issue',
+          'create',
+          '--title',
+          `${ISSUE_TITLE} (${new Date().toISOString().slice(0, 10)})`,
+          '--body',
+          body,
+        ]);
+      }
+    },
+
+    async openClosurePr(removed: Restaurant[]): Promise<void> {
+      const names = removed.map(r => r.name).join(', ');
+      await execFileAsync('git', ['checkout', '-B', PR_BRANCH]);
+      await execFileAsync('git', ['add', '-A']);
+      await execFileAsync('git', [
+        'commit',
+        '-m',
+        `chore: remove permanently closed restaurants (${names})`,
+      ]);
+      await execFileAsync('git', ['push', '-f', 'origin', PR_BRANCH]);
+      await gh([
+        'pr',
+        'create',
+        '--title',
+        `Remove closed restaurants: ${names}`,
+        '--body',
+        `Auto-detected as CLOSED_PERMANENTLY by the Places API:\n\n${removed
+          .map(r => `- ${r.name} (\`${r.slug}\`)`)
+          .join('\n')}`,
+        '--head',
+        PR_BRANCH,
+      ]);
+    },
+
+    log(msg: string): void {
+      console.log(msg);
+    },
+  };
+}

--- a/scripts/check-restaurants/geo.test.ts
+++ b/scripts/check-restaurants/geo.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, test } from 'vitest';
 
-import { haversineMeters, isWithinCorridor, projectToSegment } from './geo';
+import {
+  haversineMeters,
+  isWithinCorridor,
+  projectToSegment,
+  tileCentersAlongSegment,
+} from './geo';
+import type { LatLng } from './types';
 
 const BRADDOCK = { lat: 38.8204, lng: -77.061 };
 const COMMONWEALTH = { lat: 38.8348, lng: -77.0672 };
@@ -39,9 +45,9 @@ describe('isWithinCorridor', () => {
   test('point ~one block (120 m) east is still inside a 150 m corridor', () => {
     // ~120 m east ≈ +0.00138 deg lng at this latitude
     const eastOfAvenue = { lat: 38.8276, lng: -77.0641 + 0.00138 };
-    expect(isWithinCorridor(eastOfAvenue, BRADDOCK, COMMONWEALTH, 150, 50)).toBe(
-      true,
-    );
+    expect(
+      isWithinCorridor(eastOfAvenue, BRADDOCK, COMMONWEALTH, 150, 50),
+    ).toBe(true);
   });
 
   test('point ~400 m east is outside a 150 m corridor', () => {
@@ -53,6 +59,72 @@ describe('isWithinCorridor', () => {
 
   test('point well south of Braddock is outside (beyond end buffer)', () => {
     const south = { lat: 38.815, lng: -77.0595 };
-    expect(isWithinCorridor(south, BRADDOCK, COMMONWEALTH, 150, 50)).toBe(false);
+    expect(isWithinCorridor(south, BRADDOCK, COMMONWEALTH, 150, 50)).toBe(
+      false,
+    );
+  });
+});
+
+describe('tileCentersAlongSegment', () => {
+  test('returns a sane number of tiles for the real segment with spacing 200 / extend 50', () => {
+    const tiles = tileCentersAlongSegment(BRADDOCK, COMMONWEALTH, 200, 50);
+    // Segment is ~1.65 km; extended by 50 m on each end gives ~1.75 km,
+    // spaced ~200 m apart => roughly 8-12 tiles.
+    expect(tiles.length).toBeGreaterThanOrEqual(8);
+    expect(tiles.length).toBeLessThanOrEqual(12);
+  });
+
+  test('first tile is ~50 m before the start, extended away from the segment', () => {
+    const tiles = tileCentersAlongSegment(BRADDOCK, COMMONWEALTH, 200, 50);
+    const first = tiles[0];
+    expect(first).toBeDefined();
+    const distFromStart = haversineMeters(first as LatLng, BRADDOCK);
+    expect(distFromStart).toBeGreaterThan(40);
+    expect(distFromStart).toBeLessThan(60);
+    // It should be on the far side of start relative to the segment (alongMeters < 0).
+    const { alongMeters } = projectToSegment(
+      first as LatLng,
+      BRADDOCK,
+      COMMONWEALTH,
+    );
+    expect(alongMeters).toBeLessThan(0);
+  });
+
+  test('last tile is ~50 m beyond the end, extended away from the segment', () => {
+    const tiles = tileCentersAlongSegment(BRADDOCK, COMMONWEALTH, 200, 50);
+    const last = tiles[tiles.length - 1];
+    expect(last).toBeDefined();
+    const distFromEnd = haversineMeters(last as LatLng, COMMONWEALTH);
+    expect(distFromEnd).toBeGreaterThan(40);
+    expect(distFromEnd).toBeLessThan(60);
+    const { alongMeters, segLengthMeters } = projectToSegment(
+      last as LatLng,
+      BRADDOCK,
+      COMMONWEALTH,
+    );
+    expect(alongMeters).toBeGreaterThan(segLengthMeters);
+  });
+
+  test('consecutive tiles are spaced no more than ~spacing apart', () => {
+    const tiles = tileCentersAlongSegment(BRADDOCK, COMMONWEALTH, 200, 50);
+    for (let i = 1; i < tiles.length; i++) {
+      const prev = tiles[i - 1];
+      const curr = tiles[i];
+      expect(prev).toBeDefined();
+      expect(curr).toBeDefined();
+      const gap = haversineMeters(prev as LatLng, curr as LatLng);
+      expect(gap).toBeLessThanOrEqual(210);
+    }
+  });
+
+  test('guarantees at least one point even for a zero-length segment', () => {
+    const tiles = tileCentersAlongSegment(BRADDOCK, BRADDOCK, 200, 50);
+    expect(tiles.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('guarantees at least one point for a very short segment with large spacing', () => {
+    const nearby = { lat: 38.8205, lng: -77.061 };
+    const tiles = tileCentersAlongSegment(BRADDOCK, nearby, 500, 0);
+    expect(tiles.length).toBeGreaterThanOrEqual(1);
   });
 });

--- a/scripts/check-restaurants/geo.test.ts
+++ b/scripts/check-restaurants/geo.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'vitest';
+
+import { haversineMeters, isWithinCorridor, projectToSegment } from './geo';
+
+const BRADDOCK = { lat: 38.8204, lng: -77.061 };
+const COMMONWEALTH = { lat: 38.8348, lng: -77.0672 };
+
+describe('haversineMeters', () => {
+  test('zero distance for identical points', () => {
+    expect(haversineMeters(BRADDOCK, BRADDOCK)).toBeCloseTo(0, 5);
+  });
+
+  test('matches known distance between the two endpoints (~1.65 km)', () => {
+    const d = haversineMeters(BRADDOCK, COMMONWEALTH);
+    expect(d).toBeGreaterThan(1500);
+    expect(d).toBeLessThan(1800);
+  });
+});
+
+describe('projectToSegment', () => {
+  test('a point on the segment start has ~0 perpendicular and ~0 along distance', () => {
+    const r = projectToSegment(BRADDOCK, BRADDOCK, COMMONWEALTH);
+    expect(r.perpMeters).toBeCloseTo(0, 1);
+    expect(r.alongMeters).toBeCloseTo(0, 1);
+  });
+
+  test('along distance at the end equals segment length', () => {
+    const r = projectToSegment(COMMONWEALTH, BRADDOCK, COMMONWEALTH);
+    expect(r.alongMeters).toBeCloseTo(r.segLengthMeters, 0);
+  });
+});
+
+describe('isWithinCorridor', () => {
+  test('point near the midpoint of the avenue is inside', () => {
+    const mid = { lat: 38.8276, lng: -77.0641 };
+    expect(isWithinCorridor(mid, BRADDOCK, COMMONWEALTH, 150, 50)).toBe(true);
+  });
+
+  test('point ~one block (120 m) east is still inside a 150 m corridor', () => {
+    // ~120 m east ≈ +0.00138 deg lng at this latitude
+    const eastOfAvenue = { lat: 38.8276, lng: -77.0641 + 0.00138 };
+    expect(isWithinCorridor(eastOfAvenue, BRADDOCK, COMMONWEALTH, 150, 50)).toBe(
+      true,
+    );
+  });
+
+  test('point ~400 m east is outside a 150 m corridor', () => {
+    const farEast = { lat: 38.8276, lng: -77.0641 + 0.0046 };
+    expect(isWithinCorridor(farEast, BRADDOCK, COMMONWEALTH, 150, 50)).toBe(
+      false,
+    );
+  });
+
+  test('point well south of Braddock is outside (beyond end buffer)', () => {
+    const south = { lat: 38.815, lng: -77.0595 };
+    expect(isWithinCorridor(south, BRADDOCK, COMMONWEALTH, 150, 50)).toBe(false);
+  });
+});

--- a/scripts/check-restaurants/geo.ts
+++ b/scripts/check-restaurants/geo.ts
@@ -18,10 +18,24 @@ export function haversineMeters(a: LatLng, b: LatLng): number {
 // Local equirectangular projection: returns metric (x east, y north) relative
 // to the origin point. Accurate over the short distances used here.
 function toLocalMeters(p: LatLng, origin: LatLng): { x: number; y: number } {
-  const x = toRad(p.lng - origin.lng) * Math.cos(toRad(origin.lat)) *
-    EARTH_RADIUS_M;
+  const x =
+    toRad(p.lng - origin.lng) * Math.cos(toRad(origin.lat)) * EARTH_RADIUS_M;
   const y = toRad(p.lat - origin.lat) * EARTH_RADIUS_M;
   return { x, y };
+}
+
+// Inverse of toLocalMeters: converts a metric offset (x east, y north) from
+// origin back into lat/lng. Accurate over the short distances used here.
+function fromLocalMeters(
+  offset: { x: number; y: number },
+  origin: LatLng,
+): LatLng {
+  const lat = origin.lat + (offset.y / EARTH_RADIUS_M) * (180 / Math.PI);
+  const lng =
+    origin.lng +
+    (offset.x / (EARTH_RADIUS_M * Math.cos(toRad(origin.lat)))) *
+      (180 / Math.PI);
+  return { lat, lng };
 }
 
 export function projectToSegment(
@@ -63,4 +77,39 @@ export function isWithinCorridor(
     alongMeters >= -endBufferMeters &&
     alongMeters <= segLengthMeters + endBufferMeters
   );
+}
+
+// Returns evenly-spaced points along the line from `start` to `end`,
+// extended by `extendMeters` beyond each endpoint, with consecutive points
+// ~`spacingMeters` apart. Always includes both extended ends and guarantees
+// at least one point (the midpoint) even for a zero-length segment.
+export function tileCentersAlongSegment(
+  start: LatLng,
+  end: LatLng,
+  spacingMeters: number,
+  extendMeters: number,
+): LatLng[] {
+  const dir = toLocalMeters(end, start);
+  const segLengthMeters = Math.hypot(dir.x, dir.y);
+
+  if (segLengthMeters === 0) {
+    return [start];
+  }
+
+  const ux = dir.x / segLengthMeters;
+  const uy = dir.y / segLengthMeters;
+
+  const totalLengthMeters = segLengthMeters + 2 * extendMeters;
+  // Number of segments needed to cover totalLengthMeters at ~spacingMeters
+  // apart, always at least 1 (which yields the two extended endpoints).
+  const segments = Math.max(1, Math.ceil(totalLengthMeters / spacingMeters));
+  const step = totalLengthMeters / segments;
+
+  const points: LatLng[] = [];
+  for (let i = 0; i <= segments; i++) {
+    const alongMeters = -extendMeters + i * step;
+    const offset = { x: ux * alongMeters, y: uy * alongMeters };
+    points.push(fromLocalMeters(offset, start));
+  }
+  return points;
 }

--- a/scripts/check-restaurants/geo.ts
+++ b/scripts/check-restaurants/geo.ts
@@ -1,0 +1,66 @@
+import type { LatLng } from './types';
+
+const EARTH_RADIUS_M = 6_371_000;
+
+const toRad = (deg: number): number => (deg * Math.PI) / 180;
+
+export function haversineMeters(a: LatLng, b: LatLng): number {
+  const dLat = toRad(b.lat - a.lat);
+  const dLng = toRad(b.lng - a.lng);
+  const lat1 = toRad(a.lat);
+  const lat2 = toRad(b.lat);
+  const h =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLng / 2) ** 2;
+  return 2 * EARTH_RADIUS_M * Math.asin(Math.sqrt(h));
+}
+
+// Local equirectangular projection: returns metric (x east, y north) relative
+// to the origin point. Accurate over the short distances used here.
+function toLocalMeters(p: LatLng, origin: LatLng): { x: number; y: number } {
+  const x = toRad(p.lng - origin.lng) * Math.cos(toRad(origin.lat)) *
+    EARTH_RADIUS_M;
+  const y = toRad(p.lat - origin.lat) * EARTH_RADIUS_M;
+  return { x, y };
+}
+
+export function projectToSegment(
+  p: LatLng,
+  a: LatLng,
+  b: LatLng,
+): { perpMeters: number; alongMeters: number; segLengthMeters: number } {
+  const pv = toLocalMeters(p, a);
+  const bv = toLocalMeters(b, a);
+  const segLengthMeters = Math.hypot(bv.x, bv.y);
+  if (segLengthMeters === 0) {
+    return {
+      perpMeters: Math.hypot(pv.x, pv.y),
+      alongMeters: 0,
+      segLengthMeters: 0,
+    };
+  }
+  const ux = bv.x / segLengthMeters;
+  const uy = bv.y / segLengthMeters;
+  const alongMeters = pv.x * ux + pv.y * uy;
+  const perpMeters = Math.abs(pv.x * uy - pv.y * ux);
+  return { perpMeters, alongMeters, segLengthMeters };
+}
+
+export function isWithinCorridor(
+  p: LatLng,
+  segStart: LatLng,
+  segEnd: LatLng,
+  widthMeters: number,
+  endBufferMeters: number,
+): boolean {
+  const { perpMeters, alongMeters, segLengthMeters } = projectToSegment(
+    p,
+    segStart,
+    segEnd,
+  );
+  return (
+    perpMeters <= widthMeters &&
+    alongMeters >= -endBufferMeters &&
+    alongMeters <= segLengthMeters + endBufferMeters
+  );
+}

--- a/scripts/check-restaurants/main.ts
+++ b/scripts/check-restaurants/main.ts
@@ -1,0 +1,23 @@
+import { createRealEffects } from './effects';
+import { createPlacesClient } from './places-client';
+import { run } from './run';
+
+async function main(): Promise<void> {
+  const apiKey = process.env['GOOGLE_PLACES_API_KEY'];
+  if (!apiKey) {
+    console.error('GOOGLE_PLACES_API_KEY is not set.');
+    process.exit(1);
+  }
+
+  const client = createPlacesClient(apiKey);
+  const effects = createRealEffects();
+  const result = await run(client, effects);
+
+  console.log(JSON.stringify(result));
+  if (result.aborted) process.exit(1);
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/check-restaurants/places-client.test.ts
+++ b/scripts/check-restaurants/places-client.test.ts
@@ -10,7 +10,7 @@ function jsonResponse(body: unknown, status = 200): Response {
 }
 
 describe('searchNearby', () => {
-  test('maps API places into DiscoveredPlace and sends key + field mask', async () => {
+  test('calls fetch once per tile center and maps API places into DiscoveredPlace', async () => {
     const fetchFn = vi.fn(async () =>
       jsonResponse({
         places: [
@@ -31,17 +31,9 @@ describe('searchNearby', () => {
     );
     const places = await client.searchNearby();
 
-    expect(places).toHaveLength(1);
-    expect(places[0]).toMatchObject({
-      placeId: 'p-1',
-      name: 'Lena’s',
-      address: '401 E Braddock Rd',
-      website: 'https://lenaswoodfire.com',
-      businessStatus: 'OPERATIONAL',
-      location: { lat: 38.83, lng: -77.065 },
-    });
+    // One call per tile center along the corridor (more than one tile).
+    expect(fetchFn.mock.calls.length).toBeGreaterThan(1);
 
-    expect(fetchFn.mock.calls.length).toBeGreaterThan(0);
     const call = fetchFn.mock.calls[0] as unknown as [
       string | URL | Request,
       RequestInit | undefined,
@@ -51,6 +43,105 @@ describe('searchNearby', () => {
     const headers = (init as RequestInit).headers as Record<string, string>;
     expect(headers['X-Goog-Api-Key']).toBe('KEY');
     expect(headers['X-Goog-FieldMask']).toContain('places.businessStatus');
+
+    // Same placeId returned by every tile (mocked the same way) is unioned
+    // and de-duplicated, so it appears exactly once in the final result.
+    expect(places).toHaveLength(1);
+    expect(places[0]).toMatchObject({
+      placeId: 'p-1',
+      name: 'Lena’s',
+      address: '401 E Braddock Rd',
+      website: 'https://lenaswoodfire.com',
+      businessStatus: 'OPERATIONAL',
+      location: { lat: 38.83, lng: -77.065 },
+    });
+  });
+
+  test('unions and de-duplicates places returned by different tiles', async () => {
+    let call = 0;
+    const fetchFn = vi.fn(async () => {
+      call += 1;
+      if (call === 1) {
+        return jsonResponse({
+          places: [
+            {
+              id: 'p-shared',
+              displayName: { text: 'Shared Place' },
+              formattedAddress: '1 Mount Vernon Ave',
+              location: { latitude: 38.82, longitude: -77.06 },
+              businessStatus: 'OPERATIONAL',
+            },
+            {
+              id: 'p-only-tile-1',
+              displayName: { text: 'Only In Tile 1' },
+              formattedAddress: '2 Mount Vernon Ave',
+              location: { latitude: 38.821, longitude: -77.0605 },
+              businessStatus: 'OPERATIONAL',
+            },
+          ],
+        });
+      }
+      // Every subsequent tile call returns the shared place plus, on the
+      // second call only, a place unique to that tile.
+      return jsonResponse({
+        places: [
+          {
+            id: 'p-shared',
+            displayName: { text: 'Shared Place' },
+            formattedAddress: '1 Mount Vernon Ave',
+            location: { latitude: 38.82, longitude: -77.06 },
+            businessStatus: 'OPERATIONAL',
+          },
+          ...(call === 2
+            ? [
+                {
+                  id: 'p-only-tile-2',
+                  displayName: { text: 'Only In Tile 2' },
+                  formattedAddress: '3 Mount Vernon Ave',
+                  location: { latitude: 38.822, longitude: -77.061 },
+                  businessStatus: 'OPERATIONAL',
+                },
+              ]
+            : []),
+        ],
+      });
+    });
+    const client = createPlacesClient(
+      'KEY',
+      fetchFn as unknown as typeof fetch,
+    );
+    const places = await client.searchNearby();
+
+    expect(fetchFn.mock.calls.length).toBeGreaterThan(1);
+
+    const placeIds = places.map(p => p.placeId).sort();
+    expect(placeIds).toEqual(
+      ['p-only-tile-1', 'p-only-tile-2', 'p-shared'].sort(),
+    );
+    // The shared placeId must appear exactly once despite being returned by
+    // every tile.
+    expect(placeIds.filter(id => id === 'p-shared')).toHaveLength(1);
+  });
+
+  test('drops a place whose location is missing rather than coercing to {0,0}', async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonResponse({
+        places: [
+          {
+            id: 'p-no-location',
+            displayName: { text: 'No Location' },
+            formattedAddress: '1 Mount Vernon Ave',
+            businessStatus: 'OPERATIONAL',
+          },
+        ],
+      }),
+    );
+    const client = createPlacesClient(
+      'KEY',
+      fetchFn as unknown as typeof fetch,
+    );
+    const places = await client.searchNearby();
+    expect(places).toHaveLength(0);
   });
 
   test('defaults website to null when absent', async () => {
@@ -75,8 +166,13 @@ describe('searchNearby', () => {
     expect(places[0]?.website).toBeNull();
   });
 
-  test('throws on non-OK search response', async () => {
-    const fetchFn = vi.fn(async () => jsonResponse({ error: 'bad' }, 400));
+  test('throws if any tile request returns a non-OK response', async () => {
+    let call = 0;
+    const fetchFn = vi.fn(async () => {
+      call += 1;
+      if (call === 3) return jsonResponse({ error: 'bad' }, 400);
+      return jsonResponse({ places: [] });
+    });
     const client = createPlacesClient(
       'KEY',
       fetchFn as unknown as typeof fetch,

--- a/scripts/check-restaurants/places-client.test.ts
+++ b/scripts/check-restaurants/places-client.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test, vi } from 'vitest';
+
+import { createPlacesClient } from './places-client';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('searchNearby', () => {
+  test('maps API places into DiscoveredPlace and sends key + field mask', async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonResponse({
+        places: [
+          {
+            id: 'p-1',
+            displayName: { text: 'Lena’s' },
+            formattedAddress: '401 E Braddock Rd',
+            location: { latitude: 38.83, longitude: -77.065 },
+            websiteUri: 'https://lenaswoodfire.com',
+            businessStatus: 'OPERATIONAL',
+          },
+        ],
+      }),
+    );
+    const client = createPlacesClient(
+      'KEY',
+      fetchFn as unknown as typeof fetch,
+    );
+    const places = await client.searchNearby();
+
+    expect(places).toHaveLength(1);
+    expect(places[0]).toMatchObject({
+      placeId: 'p-1',
+      name: 'Lena’s',
+      address: '401 E Braddock Rd',
+      website: 'https://lenaswoodfire.com',
+      businessStatus: 'OPERATIONAL',
+      location: { lat: 38.83, lng: -77.065 },
+    });
+
+    expect(fetchFn.mock.calls.length).toBeGreaterThan(0);
+    const call = fetchFn.mock.calls[0] as unknown as [
+      string | URL | Request,
+      RequestInit | undefined,
+    ];
+    const [url, init] = call;
+    expect(String(url)).toContain('places:searchNearby');
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers['X-Goog-Api-Key']).toBe('KEY');
+    expect(headers['X-Goog-FieldMask']).toContain('places.businessStatus');
+  });
+
+  test('defaults website to null when absent', async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonResponse({
+        places: [
+          {
+            id: 'p-2',
+            displayName: { text: 'No Site' },
+            formattedAddress: '1 Mount Vernon Ave',
+            location: { latitude: 38.82, longitude: -77.06 },
+            businessStatus: 'OPERATIONAL',
+          },
+        ],
+      }),
+    );
+    const client = createPlacesClient(
+      'KEY',
+      fetchFn as unknown as typeof fetch,
+    );
+    const places = await client.searchNearby();
+    expect(places[0]?.website).toBeNull();
+  });
+
+  test('throws on non-OK search response', async () => {
+    const fetchFn = vi.fn(async () => jsonResponse({ error: 'bad' }, 400));
+    const client = createPlacesClient(
+      'KEY',
+      fetchFn as unknown as typeof fetch,
+    );
+    await expect(client.searchNearby()).rejects.toThrow();
+  });
+});
+
+describe('getPlaceStatus', () => {
+  test('returns the business status', async () => {
+    const fetchFn = vi.fn(async () =>
+      jsonResponse({ businessStatus: 'CLOSED_PERMANENTLY' }),
+    );
+    const client = createPlacesClient(
+      'KEY',
+      fetchFn as unknown as typeof fetch,
+    );
+    expect(await client.getPlaceStatus('p-x')).toBe('CLOSED_PERMANENTLY');
+  });
+
+  test('returns NOT_FOUND on 404', async () => {
+    const fetchFn = vi.fn(async () => jsonResponse({ error: 'no' }, 404));
+    const client = createPlacesClient(
+      'KEY',
+      fetchFn as unknown as typeof fetch,
+    );
+    expect(await client.getPlaceStatus('p-missing')).toBe('NOT_FOUND');
+  });
+});

--- a/scripts/check-restaurants/places-client.ts
+++ b/scripts/check-restaurants/places-client.ts
@@ -1,0 +1,100 @@
+import { INCLUDED_TYPES, SEARCH_CENTER, SEARCH_RADIUS_METERS } from './config';
+import type { BusinessStatus, DiscoveredPlace } from './types';
+
+const SEARCH_URL = 'https://places.googleapis.com/v1/places:searchNearby';
+const DETAILS_URL = 'https://places.googleapis.com/v1/places';
+
+const SEARCH_FIELD_MASK = [
+  'places.id',
+  'places.displayName',
+  'places.formattedAddress',
+  'places.location',
+  'places.websiteUri',
+  'places.businessStatus',
+].join(',');
+
+interface ApiPlace {
+  id: string;
+  displayName?: { text?: string };
+  formattedAddress?: string;
+  location?: { latitude: number; longitude: number };
+  websiteUri?: string;
+  businessStatus?: BusinessStatus;
+}
+
+export interface PlacesClient {
+  searchNearby(): Promise<DiscoveredPlace[]>;
+  getPlaceStatus(placeId: string): Promise<BusinessStatus | 'NOT_FOUND'>;
+}
+
+function mapPlace(p: ApiPlace): DiscoveredPlace {
+  return {
+    placeId: p.id,
+    name: p.displayName?.text ?? '',
+    address: p.formattedAddress ?? '',
+    location: {
+      lat: p.location?.latitude ?? 0,
+      lng: p.location?.longitude ?? 0,
+    },
+    website: p.websiteUri ?? null,
+    businessStatus: p.businessStatus ?? 'OPERATIONAL',
+  };
+}
+
+export function createPlacesClient(
+  apiKey: string,
+  fetchFn: typeof fetch = fetch,
+): PlacesClient {
+  return {
+    async searchNearby(): Promise<DiscoveredPlace[]> {
+      const res = await fetchFn(SEARCH_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Goog-Api-Key': apiKey,
+          'X-Goog-FieldMask': SEARCH_FIELD_MASK,
+        },
+        body: JSON.stringify({
+          includedTypes: INCLUDED_TYPES,
+          maxResultCount: 20,
+          locationRestriction: {
+            circle: {
+              center: {
+                latitude: SEARCH_CENTER.lat,
+                longitude: SEARCH_CENTER.lng,
+              },
+              radius: SEARCH_RADIUS_METERS,
+            },
+          },
+        }),
+      });
+      if (!res.ok) {
+        throw new Error(
+          `Places searchNearby failed: ${res.status} ${await res.text()}`,
+        );
+      }
+      const data = (await res.json()) as { places?: ApiPlace[] };
+      return (data.places ?? []).map(mapPlace);
+    },
+
+    async getPlaceStatus(
+      placeId: string,
+    ): Promise<BusinessStatus | 'NOT_FOUND'> {
+      const res = await fetchFn(`${DETAILS_URL}/${placeId}`, {
+        method: 'GET',
+        headers: {
+          'X-Goog-Api-Key': apiKey,
+          'X-Goog-FieldMask': 'businessStatus',
+        },
+      });
+      if (res.status === 404) return 'NOT_FOUND';
+      if (!res.ok) {
+        throw new Error(
+          `Places details failed: ${res.status} ${await res.text()}`,
+        );
+      }
+      const data = (await res.json()) as { businessStatus?: BusinessStatus };
+      return data.businessStatus ?? 'NOT_FOUND';
+    },
+  };
+}

--- a/scripts/check-restaurants/places-client.ts
+++ b/scripts/check-restaurants/places-client.ts
@@ -1,4 +1,12 @@
-import { INCLUDED_TYPES, SEARCH_CENTER, SEARCH_RADIUS_METERS } from './config';
+import {
+  INCLUDED_TYPES,
+  SEARCH_TILE_EXTEND_METERS,
+  SEARCH_TILE_RADIUS_METERS,
+  SEARCH_TILE_SPACING_METERS,
+  SEGMENT_END,
+  SEGMENT_START,
+} from './config';
+import { tileCentersAlongSegment } from './geo';
 import type { BusinessStatus, DiscoveredPlace } from './types';
 
 const SEARCH_URL = 'https://places.googleapis.com/v1/places:searchNearby';
@@ -27,14 +35,17 @@ export interface PlacesClient {
   getPlaceStatus(placeId: string): Promise<BusinessStatus | 'NOT_FOUND'>;
 }
 
-function mapPlace(p: ApiPlace): DiscoveredPlace {
+// Returns null (rather than coercing to {0,0}) when the API omits location,
+// so the caller can drop the place instead of silently mislocating it.
+function mapPlace(p: ApiPlace): DiscoveredPlace | null {
+  if (!p.location) return null;
   return {
     placeId: p.id,
     name: p.displayName?.text ?? '',
     address: p.formattedAddress ?? '',
     location: {
-      lat: p.location?.latitude ?? 0,
-      lng: p.location?.longitude ?? 0,
+      lat: p.location.latitude,
+      lng: p.location.longitude,
     },
     website: p.websiteUri ?? null,
     businessStatus: p.businessStatus ?? 'OPERATIONAL',
@@ -47,34 +58,52 @@ export function createPlacesClient(
 ): PlacesClient {
   return {
     async searchNearby(): Promise<DiscoveredPlace[]> {
-      const res = await fetchFn(SEARCH_URL, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Goog-Api-Key': apiKey,
-          'X-Goog-FieldMask': SEARCH_FIELD_MASK,
-        },
-        body: JSON.stringify({
-          includedTypes: INCLUDED_TYPES,
-          maxResultCount: 20,
-          locationRestriction: {
-            circle: {
-              center: {
-                latitude: SEARCH_CENTER.lat,
-                longitude: SEARCH_CENTER.lng,
-              },
-              radius: SEARCH_RADIUS_METERS,
-            },
+      // Places API (New) searchNearby caps results at 20 with no
+      // pagination, so we tile small overlapping circles along the
+      // corridor and union the results by placeId instead of relying on a
+      // single large-radius search.
+      const tileCenters = tileCentersAlongSegment(
+        SEGMENT_START,
+        SEGMENT_END,
+        SEARCH_TILE_SPACING_METERS,
+        SEARCH_TILE_EXTEND_METERS,
+      );
+
+      const found = new Map<string, DiscoveredPlace>();
+      for (const center of tileCenters) {
+        const res = await fetchFn(SEARCH_URL, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Goog-Api-Key': apiKey,
+            'X-Goog-FieldMask': SEARCH_FIELD_MASK,
           },
-        }),
-      });
-      if (!res.ok) {
-        throw new Error(
-          `Places searchNearby failed: ${res.status} ${await res.text()}`,
-        );
+          body: JSON.stringify({
+            includedTypes: INCLUDED_TYPES,
+            maxResultCount: 20,
+            locationRestriction: {
+              circle: {
+                center: {
+                  latitude: center.lat,
+                  longitude: center.lng,
+                },
+                radius: SEARCH_TILE_RADIUS_METERS,
+              },
+            },
+          }),
+        });
+        if (!res.ok) {
+          throw new Error(
+            `Places searchNearby failed: ${res.status} ${await res.text()}`,
+          );
+        }
+        const data = (await res.json()) as { places?: ApiPlace[] };
+        for (const apiPlace of data.places ?? []) {
+          const place = mapPlace(apiPlace);
+          if (place) found.set(place.placeId, place);
+        }
       }
-      const data = (await res.json()) as { places?: ApiPlace[] };
-      return (data.places ?? []).map(mapPlace);
+      return [...found.values()];
     },
 
     async getPlaceStatus(
@@ -93,6 +122,9 @@ export function createPlacesClient(
           `Places details failed: ${res.status} ${await res.text()}`,
         );
       }
+      // A 200 response with no businessStatus is treated the same as
+      // NOT_FOUND, which is warning-only and never triggers a removal —
+      // intentionally conservative in the face of an unexpected API shape.
       const data = (await res.json()) as { businessStatus?: BusinessStatus };
       return data.businessStatus ?? 'NOT_FOUND';
     },

--- a/scripts/check-restaurants/report.test.ts
+++ b/scripts/check-restaurants/report.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  applyBackfills,
+  applyClosures,
+  buildIssueBody,
+  imageFilesToDelete,
+  serializeRestaurants,
+} from './report';
+import type { DiscoveredPlace, Restaurant } from './types';
+
+const r = (over: Partial<Restaurant>): Restaurant => ({
+  name: 'X',
+  slug: 'x',
+  website: 'https://x.com',
+  onlineOrderUrl: 'https://x.com/order',
+  ...over,
+});
+
+const d = (over: Partial<DiscoveredPlace>): DiscoveredPlace => ({
+  placeId: 'p-new',
+  name: 'New Spot',
+  location: { lat: 38.8276, lng: -77.0641 },
+  address: '2000 Mount Vernon Ave',
+  website: 'https://newspot.com',
+  businessStatus: 'OPERATIONAL',
+  ...over,
+});
+
+describe('applyClosures', () => {
+  test('removes closed entries, leaves the rest, does not mutate input', () => {
+    const input = [r({ slug: 'keep' }), r({ slug: 'gone' })];
+    const out = applyClosures(input, [r({ slug: 'gone' })]);
+    expect(out.map(x => x.slug)).toEqual(['keep']);
+    expect(input).toHaveLength(2);
+  });
+});
+
+describe('applyBackfills', () => {
+  test('sets placeId on matching slugs only', () => {
+    const input = [r({ slug: 'a' }), r({ slug: 'b' })];
+    const out = applyBackfills(input, [{ slug: 'b', placeId: 'p-b' }]);
+    expect(out.find(x => x.slug === 'a')?.placeId).toBeUndefined();
+    expect(out.find(x => x.slug === 'b')?.placeId).toBe('p-b');
+  });
+});
+
+describe('imageFilesToDelete', () => {
+  test('maps slugs to image paths', () => {
+    expect(imageFilesToDelete([r({ slug: 'gone' })])).toEqual([
+      'src/assets/images/gone.png',
+    ]);
+  });
+});
+
+describe('serializeRestaurants', () => {
+  test('2-space indented JSON ending in a newline', () => {
+    const out = serializeRestaurants([r({ slug: 'x' })]);
+    expect(out.endsWith('\n')).toBe(true);
+    expect(out).toContain('  "slug": "x"');
+  });
+});
+
+describe('buildIssueBody', () => {
+  test('includes addition name, website, slug suggestion, and placeId', () => {
+    const body = buildIssueBody([d({ name: 'New Spot' })], []);
+    expect(body).toContain('New Spot');
+    expect(body).toContain('https://newspot.com');
+    expect(body).toContain('new-spot');
+    expect(body).toContain('p-new');
+    expect(body).toContain('maps.google.com');
+  });
+
+  test('renders warnings section when present', () => {
+    const body = buildIssueBody([], ['thai-peppers: verify manually.']);
+    expect(body).toContain('Warnings');
+    expect(body).toContain('thai-peppers: verify manually.');
+  });
+
+  test('states when there is nothing to add', () => {
+    const body = buildIssueBody([], []);
+    expect(body.toLowerCase()).toContain('no new');
+  });
+});

--- a/scripts/check-restaurants/report.ts
+++ b/scripts/check-restaurants/report.ts
@@ -1,0 +1,69 @@
+import { slugify } from './diff';
+import type { DiscoveredPlace, Restaurant } from './types';
+
+export function applyClosures(
+  restaurants: Restaurant[],
+  closures: Restaurant[],
+): Restaurant[] {
+  const closedSlugs = new Set(closures.map(c => c.slug));
+  return restaurants.filter(r => !closedSlugs.has(r.slug));
+}
+
+export function applyBackfills(
+  restaurants: Restaurant[],
+  backfills: Array<{ slug: string; placeId: string }>,
+): Restaurant[] {
+  const bySlug = new Map(backfills.map(b => [b.slug, b.placeId]));
+  return restaurants.map(r => {
+    const placeId = bySlug.get(r.slug);
+    return placeId ? { ...r, placeId } : r;
+  });
+}
+
+export function imageFilesToDelete(closures: Restaurant[]): string[] {
+  return closures.map(c => `src/assets/images/${c.slug}.png`);
+}
+
+export function serializeRestaurants(restaurants: Restaurant[]): string {
+  return `${JSON.stringify(restaurants, null, 2)}\n`;
+}
+
+export function buildIssueBody(
+  additions: DiscoveredPlace[],
+  warnings: string[],
+): string {
+  const lines: string[] = [];
+  lines.push('## Restaurant directory check');
+  lines.push('');
+
+  if (additions.length === 0) {
+    lines.push('No new restaurant candidates found.');
+  } else {
+    lines.push(`### ${additions.length} new candidate(s)`);
+    lines.push('');
+    lines.push(
+      'Finish each by adding an `onlineOrderUrl` and a `<slug>.png` image.',
+    );
+    lines.push('');
+    for (const a of additions) {
+      const slug = slugify(a.name);
+      const mapsUrl = `https://maps.google.com/?q=place_id:${a.placeId}`;
+      lines.push(`- **${a.name}**`);
+      lines.push(`  - Address: ${a.address}`);
+      lines.push(`  - Website: ${a.website ?? '(none provided)'}`);
+      lines.push(`  - Suggested slug: \`${slug}\``);
+      lines.push(`  - placeId: \`${a.placeId}\``);
+      lines.push(`  - Google Maps: ${mapsUrl}`);
+    }
+  }
+
+  if (warnings.length > 0) {
+    lines.push('');
+    lines.push('### Warnings');
+    lines.push('');
+    for (const w of warnings) lines.push(`- ${w}`);
+  }
+
+  lines.push('');
+  return lines.join('\n');
+}

--- a/scripts/check-restaurants/run.test.ts
+++ b/scripts/check-restaurants/run.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from 'vitest';
+
+import type { PlacesClient } from './places-client';
+import { type Effects, run } from './run';
+import type { BusinessStatus, DiscoveredPlace, Restaurant } from './types';
+
+const onAvenue = { lat: 38.8276, lng: -77.0641 };
+
+function fakeClient(
+  discovered: DiscoveredPlace[],
+  statuses: Record<string, BusinessStatus | 'NOT_FOUND'>,
+): PlacesClient {
+  return {
+    searchNearby: async () => discovered,
+    getPlaceStatus: async id => statuses[id] ?? 'NOT_FOUND',
+  };
+}
+
+function fakeEffects(existing: Restaurant[]): Effects & {
+  written: string[];
+  deleted: string[];
+  issues: string[];
+  prs: Restaurant[][];
+} {
+  const written: string[] = [];
+  const deleted: string[] = [];
+  const issues: string[] = [];
+  const prs: Restaurant[][] = [];
+  return {
+    written,
+    deleted,
+    issues,
+    prs,
+    readRestaurants: async () => existing,
+    writeRestaurants: async json => {
+      written.push(json);
+    },
+    deleteImages: async paths => {
+      deleted.push(...paths);
+    },
+    reportIssue: async body => {
+      issues.push(body);
+    },
+    openClosurePr: async removed => {
+      prs.push(removed);
+    },
+    log: () => {},
+  };
+}
+
+function place(over: Partial<DiscoveredPlace>): DiscoveredPlace {
+  return {
+    placeId: 'p',
+    name: 'P',
+    location: onAvenue,
+    address: '2000 Mount Vernon Ave',
+    website: null,
+    businessStatus: 'OPERATIONAL',
+    ...over,
+  };
+}
+
+// Build N operational corridor places so the guard passes.
+function padPlaces(n: number): DiscoveredPlace[] {
+  return Array.from({ length: n }, (_, i) =>
+    place({ placeId: `pad-${i}`, name: `Pad ${i}` }),
+  );
+}
+
+describe('run', () => {
+  test('aborts without removals when too few corridor results', async () => {
+    const existing: Restaurant[] = [
+      {
+        name: 'Gone',
+        slug: 'gone',
+        website: '',
+        onlineOrderUrl: '',
+        placeId: 'p-gone',
+      },
+    ];
+    const client = fakeClient([place({ placeId: 'only', name: 'Only One' })], {
+      'p-gone': 'CLOSED_PERMANENTLY',
+    });
+    const effects = fakeEffects(existing);
+    const result = await run(client, effects);
+
+    expect(result.aborted).toBe(true);
+    expect(effects.written).toHaveLength(0);
+    expect(effects.deleted).toHaveLength(0);
+    expect(effects.prs).toHaveLength(0);
+  });
+
+  test('removes a permanently closed restaurant and opens a PR', async () => {
+    const existing: Restaurant[] = [
+      {
+        name: 'Gone',
+        slug: 'gone',
+        website: '',
+        onlineOrderUrl: '',
+        placeId: 'p-gone',
+      },
+    ];
+    const client = fakeClient(padPlaces(12), {
+      'p-gone': 'CLOSED_PERMANENTLY',
+    });
+    const effects = fakeEffects(existing);
+    const result = await run(client, effects);
+
+    expect(result.aborted).toBe(false);
+    expect(result.closures).toBe(1);
+    expect(effects.deleted).toContain('src/assets/images/gone.png');
+    expect(effects.prs[0]?.map(r => r.slug)).toEqual(['gone']);
+    expect(effects.written[0]).not.toContain('"gone"');
+  });
+
+  test('filters out-of-corridor discoveries from additions', async () => {
+    const farEast = place({
+      placeId: 'p-far',
+      name: 'Far Away Diner',
+      location: { lat: 38.8276, lng: -77.0641 + 0.01 },
+    });
+    const client = fakeClient([...padPlaces(12), farEast], {});
+    const effects = fakeEffects([]);
+    const result = await run(client, effects);
+
+    // padPlaces are all in-corridor and become additions; farEast must not.
+    expect(effects.issues[0]).not.toContain('Far Away Diner');
+    expect(result.additions).toBe(12);
+  });
+
+  test('always reports an issue', async () => {
+    const client = fakeClient(padPlaces(12), {});
+    const effects = fakeEffects([]);
+    await run(client, effects);
+    expect(effects.issues).toHaveLength(1);
+  });
+});

--- a/scripts/check-restaurants/run.test.ts
+++ b/scripts/check-restaurants/run.test.ts
@@ -21,16 +21,19 @@ function fakeEffects(existing: Restaurant[]): Effects & {
   deleted: string[];
   issues: string[];
   prs: Restaurant[][];
+  backfillPrs: Array<Array<{ slug: string; placeId: string }>>;
 } {
   const written: string[] = [];
   const deleted: string[] = [];
   const issues: string[] = [];
   const prs: Restaurant[][] = [];
+  const backfillPrs: Array<Array<{ slug: string; placeId: string }>> = [];
   return {
     written,
     deleted,
     issues,
     prs,
+    backfillPrs,
     readRestaurants: async () => existing,
     writeRestaurants: async json => {
       written.push(json);
@@ -43,6 +46,9 @@ function fakeEffects(existing: Restaurant[]): Effects & {
     },
     openClosurePr: async removed => {
       prs.push(removed);
+    },
+    openBackfillPr: async backfills => {
+      backfillPrs.push(backfills);
     },
     log: () => {},
   };
@@ -132,6 +138,72 @@ describe('run', () => {
     const client = fakeClient(padPlaces(12), {});
     const effects = fakeEffects([]);
     await run(client, effects);
+    expect(effects.issues).toHaveLength(1);
+  });
+
+  test('backfills only: opens a backfill PR and writes restaurants, but does not open a closure PR', async () => {
+    const existing: Restaurant[] = [
+      {
+        name: 'Found Me',
+        slug: 'found-me',
+        website: '',
+        onlineOrderUrl: '',
+      },
+    ];
+    const discovered = [
+      place({ placeId: 'p-found', name: 'Found Me' }),
+      ...padPlaces(12),
+    ];
+    const client = fakeClient(discovered, {});
+    const effects = fakeEffects(existing);
+    const result = await run(client, effects);
+
+    expect(result.aborted).toBe(false);
+    expect(result.closures).toBe(0);
+    expect(result.backfills).toBe(1);
+    expect(effects.backfillPrs).toHaveLength(1);
+    expect(effects.backfillPrs[0]).toEqual([
+      { slug: 'found-me', placeId: 'p-found' },
+    ]);
+    expect(effects.prs).toHaveLength(0);
+    expect(effects.written).toHaveLength(1);
+    expect(effects.written[0]).toContain('p-found');
+    expect(effects.issues).toHaveLength(1);
+  });
+
+  test('closures and backfills together: opens a closure PR (not a backfill PR), and writes restaurants once', async () => {
+    const existing: Restaurant[] = [
+      {
+        name: 'Gone',
+        slug: 'gone',
+        website: '',
+        onlineOrderUrl: '',
+        placeId: 'p-gone',
+      },
+      {
+        name: 'Found Me',
+        slug: 'found-me',
+        website: '',
+        onlineOrderUrl: '',
+      },
+    ];
+    const discovered = [
+      place({ placeId: 'p-found', name: 'Found Me' }),
+      ...padPlaces(12),
+    ];
+    const client = fakeClient(discovered, {
+      'p-gone': 'CLOSED_PERMANENTLY',
+    });
+    const effects = fakeEffects(existing);
+    const result = await run(client, effects);
+
+    expect(result.aborted).toBe(false);
+    expect(result.closures).toBe(1);
+    expect(result.backfills).toBe(1);
+    expect(effects.prs).toHaveLength(1);
+    expect(effects.prs[0]?.map(r => r.slug)).toEqual(['gone']);
+    expect(effects.backfillPrs).toHaveLength(0);
+    expect(effects.written).toHaveLength(1);
     expect(effects.issues).toHaveLength(1);
   });
 });

--- a/scripts/check-restaurants/run.ts
+++ b/scripts/check-restaurants/run.ts
@@ -1,0 +1,98 @@
+import {
+  CORRIDOR_END_BUFFER_METERS,
+  CORRIDOR_WIDTH_METERS,
+  MIN_EXPECTED_RESULTS,
+  SEGMENT_END,
+  SEGMENT_START,
+} from './config';
+import { diffRestaurants } from './diff';
+import { isWithinCorridor } from './geo';
+import type { PlacesClient } from './places-client';
+import {
+  applyBackfills,
+  applyClosures,
+  buildIssueBody,
+  imageFilesToDelete,
+  serializeRestaurants,
+} from './report';
+import type { BusinessStatus, Restaurant } from './types';
+
+export interface Effects {
+  readRestaurants(): Promise<Restaurant[]>;
+  writeRestaurants(json: string): Promise<void>;
+  deleteImages(paths: string[]): Promise<void>;
+  reportIssue(body: string): Promise<void>;
+  openClosurePr(removed: Restaurant[]): Promise<void>;
+  log(msg: string): void;
+}
+
+export interface RunResult {
+  additions: number;
+  closures: number;
+  backfills: number;
+  warnings: number;
+  aborted: boolean;
+}
+
+export async function run(
+  client: PlacesClient,
+  effects: Effects,
+): Promise<RunResult> {
+  const existing = await effects.readRestaurants();
+
+  const raw = await client.searchNearby();
+  const discovered = raw.filter(p =>
+    isWithinCorridor(
+      p.location,
+      SEGMENT_START,
+      SEGMENT_END,
+      CORRIDOR_WIDTH_METERS,
+      CORRIDOR_END_BUFFER_METERS,
+    ),
+  );
+  effects.log(`Found ${raw.length} raw, ${discovered.length} within corridor.`);
+
+  if (discovered.length < MIN_EXPECTED_RESULTS) {
+    effects.log(
+      `Only ${discovered.length} corridor results (< ${MIN_EXPECTED_RESULTS}). Aborting without removals.`,
+    );
+    return {
+      additions: 0,
+      closures: 0,
+      backfills: 0,
+      warnings: 0,
+      aborted: true,
+    };
+  }
+
+  const statuses = new Map<string, BusinessStatus | 'NOT_FOUND'>();
+  for (const r of existing) {
+    if (r.placeId)
+      statuses.set(r.placeId, await client.getPlaceStatus(r.placeId));
+  }
+
+  const diff = diffRestaurants(existing, discovered, statuses);
+
+  let next = applyBackfills(existing, diff.backfills);
+  if (diff.closures.length > 0) {
+    next = applyClosures(next, diff.closures);
+  }
+
+  if (diff.backfills.length > 0 || diff.closures.length > 0) {
+    await effects.writeRestaurants(serializeRestaurants(next));
+  }
+  if (diff.closures.length > 0) {
+    await effects.deleteImages(imageFilesToDelete(diff.closures));
+    await effects.openClosurePr(diff.closures);
+  }
+
+  await effects.reportIssue(buildIssueBody(diff.additions, diff.warnings));
+
+  return {
+    additions: diff.additions.length,
+    closures: diff.closures.length,
+    backfills: diff.backfills.length,
+    warnings: diff.warnings.length,
+    aborted: false,
+  };
+}

--- a/scripts/check-restaurants/run.ts
+++ b/scripts/check-restaurants/run.ts
@@ -23,6 +23,9 @@ export interface Effects {
   deleteImages(paths: string[]): Promise<void>;
   reportIssue(body: string): Promise<void>;
   openClosurePr(removed: Restaurant[]): Promise<void>;
+  openBackfillPr(
+    backfills: Array<{ slug: string; placeId: string }>,
+  ): Promise<void>;
   log(msg: string): void;
 }
 
@@ -84,6 +87,8 @@ export async function run(
   if (diff.closures.length > 0) {
     await effects.deleteImages(imageFilesToDelete(diff.closures));
     await effects.openClosurePr(diff.closures);
+  } else if (diff.backfills.length > 0) {
+    await effects.openBackfillPr(diff.backfills);
   }
 
   await effects.reportIssue(buildIssueBody(diff.additions, diff.warnings));

--- a/scripts/check-restaurants/types.ts
+++ b/scripts/check-restaurants/types.ts
@@ -1,0 +1,26 @@
+export interface LatLng {
+  lat: number;
+  lng: number;
+}
+
+export type BusinessStatus =
+  | 'OPERATIONAL'
+  | 'CLOSED_TEMPORARILY'
+  | 'CLOSED_PERMANENTLY';
+
+export interface Restaurant {
+  name: string;
+  slug: string;
+  website: string;
+  onlineOrderUrl: string;
+  placeId?: string;
+}
+
+export interface DiscoveredPlace {
+  placeId: string;
+  name: string;
+  location: LatLng;
+  address: string;
+  website: string | null;
+  businessStatus: BusinessStatus;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['scripts/**/*.test.ts'],
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary

Automates detecting restaurants newly opened or permanently closed on the Del Ray stretch of Mount Vernon Ave (Braddock Rd → Commonwealth Ave, plus ~one block east/west), so `src/data/restaurants.json` no longer drifts out of date by hand.

A weekly GitHub Action (`workflow_dispatch` too) runs a TypeScript script that:
- **Discovers** food places via the Google Places API (New), using **tiled** `searchNearby` circles stepped along a corridor and unioned by `placeId` (avoids the API's 20-result cap), then filters to a ~150m corridor with pure point-to-segment geometry.
- **Diffs** against `restaurants.json` by stable `placeId` (new optional field; purely additive — `card.astro` is untouched).
- **Closures** (`business_status: CLOSED_PERMANENTLY`) → opens a PR removing the entry + its image.
- **New candidates** → opens/updates an Issue with name, address, Google-provided website, suggested slug, and `placeId`.
- **Backfills** (existing entries missing a `placeId`) → opens their own PR.
- **Safety guard:** aborts with no removals if the corridor returns implausibly few results; only `CLOSED_PERMANENTLY` is auto-removed (temporary-closed / dropped-out / not-found are reported, never removed).

Design + plan: `docs/superpowers/specs/2026-06-26-restaurant-discovery-automation-design.md`, `docs/superpowers/plans/2026-06-26-restaurant-discovery-automation.md`.

## Architecture

Pure, unit-tested core (`geo`, `diff`, `report`) isolated from I/O; a mockable Places client; an orchestrator (`run`) behind an injected `Effects` interface; real side effects (`effects`, via `node:fs` + `gh`) only at the edge. **45 unit tests, `tsc --noEmit` clean, production build passes.**

## Before this runs unattended

- [ ] Set the **`GOOGLE_PLACES_API_KEY`** repo secret (Actions).
- [ ] Run the one-time live backfill (Task 11): verify the two corridor endpoint coordinates in `config.ts` against the real intersections, dry-run the corridor to confirm it captures the known list, then run `pnpm check:restaurants` to backfill `placeId`s and review the diff.

## Test plan

- `pnpm test` → 45/45 passing
- `pnpm exec tsc --noEmit -p tsconfig.json` → clean
- `pnpm build` → succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)